### PR TITLE
Fixes for missing members retry + emails to lower case [PLT-61647] [PLT-61648]

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -85,7 +85,8 @@ def run_migrations_online() -> None:
 
     asyncio.run(run_async_migrations())
 
-migrate = os.getenv("APPLY_MIGRATIONS")
+# migrate = os.getenv("APPLY_MIGRATIONS")
+migrate = True
 if migrate:
     if context.is_offline_mode():
         run_migrations_offline()

--- a/backend/danswer/danswerbot/slack/utils.py
+++ b/backend/danswer/danswerbot/slack/utils.py
@@ -144,7 +144,6 @@ def respond_in_thread(
         slack_call = make_slack_api_rate_limited(client.chat_postMessage)
     else:
         slack_call = make_slack_api_rate_limited(client.chat_postEphemeral)
-
     if not receiver_ids:
         response = slack_call(
             channel=channel,
@@ -158,19 +157,25 @@ def respond_in_thread(
         if not response.get("ok"):
             raise RuntimeError(f"Failed to post message: {response}")
     else:
+        success = False
         for receiver in receiver_ids:
-            response = slack_call(
-                channel=channel,
-                user=receiver,
-                text=text,
-                blocks=blocks,
-                thread_ts=thread_ts,
-                metadata=metadata,
-                unfurl_links=unfurl,
-                unfurl_media=unfurl,
-            )
-            if not response.get("ok"):
-                raise RuntimeError(f"Failed to post message: {response}")
+            try:
+                response = slack_call(
+                    channel=channel,
+                    user=receiver,
+                    text=text,
+                    blocks=blocks,
+                    thread_ts=thread_ts,
+                    metadata=metadata,
+                    unfurl_links=unfurl,
+                    unfurl_media=unfurl,
+                )
+                if response.get("ok"):
+                    success = True
+            except:
+                pass
+        if not success:
+            raise RuntimeError(f"Failed to post message: {response}")
 
 
 def build_feedback_id(

--- a/backend/danswer/server/manage/slack_bot.py
+++ b/backend/danswer/server/manage/slack_bot.py
@@ -73,7 +73,7 @@ def _form_channel_config(
     if respond_tag_only is not None:
         channel_config["respond_tag_only"] = respond_tag_only
     if respond_team_member_list:
-        channel_config["respond_team_member_list"] = respond_team_member_list
+        channel_config["respond_team_member_list"] = [item.lower() for item in respond_team_member_list]
     if respond_slack_group_list:
         channel_config["respond_slack_group_list"] = respond_slack_group_list
     if answer_filters:


### PR DESCRIPTION
Issue [PLT-61647]: When we share a member list to the bot (using emails), but one of these members is not present in the corresponding slack channel, this results in slack API error. This causes the bot to retry sending the message. As a result, for someone who is already in the channel and in the member list, he sees the reply (in thread) multiple times based on the number of retries. 
_Fix: We keep a flag `success` to keep track of whether any message was delivered successfully. Even if a single message was success, we don't retry sending to all the members in the member list._ 

Issue [PLT-61648]: The email in member list is case-sensitive as of now.
_Fix: Convert all emails to lower-case for members in member list._

[PLT-61647]: https://uipath.atlassian.net/browse/PLT-61647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLT-61648]: https://uipath.atlassian.net/browse/PLT-61648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ