### PR TITLE
Handle Question Marks in links

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -175,6 +175,16 @@ def remove_scheduled_feedback_reminder(
                 "Unable to delete the scheduled message. It must have already been posted"
             )
 
+def contains_questionmark_outside_links(message: str) -> bool:
+    """
+    Checks if the message contains a question mark outside of URLs.
+    """
+    url_pattern = r"<https?://[^\s>]+>|https?://\S+"
+    
+    message_without_links = re.sub(url_pattern, "", message)
+    
+    return "?" in message_without_links
+
 
 def contains_questionmark_outside_links(message: str) -> bool:
     """
@@ -352,9 +362,10 @@ def handle_message(
         if not bypass_filters and "answer_filters" in channel_conf:
             reflexion = "well_answered_postfilter" in channel_conf["answer_filters"]
 
-            if "questionmark_prefilter" in channel_conf[
-                "answer_filters"
-            ] and not contains_questionmark_outside_links(messages[-1].message):
+            if (
+                "questionmark_prefilter" in channel_conf["answer_filters"]
+                and not contains_questionmark_outside_links(messages[-1].message)
+            ):
                 logger.info(
                     "Skipping message since it does not contain a question mark"
                 )

--- a/backend/danswer/danswerbot/slack/listener.py
+++ b/backend/danswer/danswerbot/slack/listener.py
@@ -209,6 +209,21 @@ def prefilter_requests(req: SocketModeRequest, client: SocketModeClient) -> bool
                 "Cannot respond to DanswerBot command without sender to respond to."
             )
             return False
+    
+    payload = req.payload
+    event = payload.get("event", {})
+    blocks = event.get("blocks", [])
+    for block in blocks:
+        if block.get("type") == "rich_text":
+            for element in block.get("elements", []):
+                if element.get("type") == "rich_text_section":
+                    for sub_element in element.get("elements", []):
+                        if (
+                            sub_element.get("type") == "broadcast"
+                            and sub_element.get("range") == "channel"
+                        ):
+                            logger.info("Broadcast message detected; skipping reply.")
+                            return False
 
     # Do not respond to messages if the channel is tagged
     payload = req.payload


### PR DESCRIPTION
Darwin was responding to queries that lacked question marks, even when the "Respond only to Questions" setting was enabled. This happened because it was detecting question marks within links in the message.  
To fix this, I have implemented a check to ignore question marks in URLs.