### PR TITLE
Add extra 10 hits for documents from user-specified prioritized sources

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -459,7 +459,7 @@ def handle_message(
         respond_tag_only = channel_conf.get("respond_tag_only") or False
         respond_team_member_list = channel_conf.get("respond_team_member_list") or None
         respond_slack_group_list = channel_conf.get("respond_slack_group_list") or None
-
+        prioritized_sources = channel_conf.get("prioritized_sources") or None
     if respond_tag_only and not bypass_filters:
         logger.info(
             "Skipping message since the channel is configured such that "
@@ -572,6 +572,7 @@ def handle_message(
             source_type=None,
             document_set=document_set_names,
             time_cutoff=None,
+            prioritized_sources=prioritized_sources,
         )
 
         # Default True because no other ways to apply filters in Slack (no nice UI)

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -1083,6 +1083,8 @@ class ChannelConfig(TypedDict):
     # If None then no follow up
     # If empty list, follow up with no tags
     follow_up_tags: NotRequired[list[str]]
+    # List of source types to prioritize in search results
+    prioritized_sources: NotRequired[list[str]]
 
 
 class SlackBotResponseType(str, PyEnum):

--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -698,19 +698,24 @@ def _query_vespa(query_params: Mapping[str, str | int | float]) -> list[Inferenc
         else {},
     )
 
-    # All records including web
+    # Get prioritized sources from filters, default to web and sfkbarticles if none
+    prioritized_sources = query_params.get("prioritized_sources") or [
+        "web",
+        "sfkbarticles",
+    ]
+    # All records
     params["hits"] = 50
     filtered_hits_all = query_vespa_helper(params)
 
-    # Only Web Records and Salesforce KB articles
+    # Records from prioritized sources
     params["hits"] = 10
-    params["yql"] = (
-        params["yql"]
-        + ' and (source_type contains "web" or source_type contains "sfkbarticles")'
+    source_conditions = " or ".join(
+        f'source_type contains "{source}"' for source in prioritized_sources
     )
-    filtered_hits_web_sf = query_vespa_helper(params)
+    params["yql"] = params["yql"] + f" and ({source_conditions})"
+    filtered_hits_prioritized = query_vespa_helper(params)
 
-    filtered_hits_final = filtered_hits_web_sf + filtered_hits_all
+    filtered_hits_final = filtered_hits_prioritized + filtered_hits_all
 
     inference_chunks = [
         _vespa_hit_to_inference_chunk(hit) for hit in filtered_hits_final
@@ -1099,6 +1104,7 @@ class VespaIndex(DocumentIndex):
             "offset": offset,
             "ranking.profile": "keyword_search",
             "timeout": _VESPA_TIMEOUT,
+            "prioritized_sources": filters.prioritized_sources,
         }
 
         return _query_vespa(params)
@@ -1141,6 +1147,7 @@ class VespaIndex(DocumentIndex):
             "offset": offset,
             "ranking.profile": f"hybrid_search{len(query_embedding)}",
             "timeout": _VESPA_TIMEOUT,
+            "prioritized_sources": filters.prioritized_sources,
         }
 
         return _query_vespa(params)
@@ -1191,6 +1198,7 @@ class VespaIndex(DocumentIndex):
             "offset": offset,
             "ranking.profile": f"hybrid_search{len(query_embedding)}",
             "timeout": _VESPA_TIMEOUT,
+            "prioritized_sources": filters.prioritized_sources,  # Use the non-None value
         }
 
         return _query_vespa(params)
@@ -1220,6 +1228,7 @@ class VespaIndex(DocumentIndex):
             "offset": 0,
             "ranking.profile": "admin_search",
             "timeout": _VESPA_TIMEOUT,
+            "prioritized_sources": filters.prioritized_sources,
         }
 
         return _query_vespa(params)

--- a/backend/danswer/search/models.py
+++ b/backend/danswer/search/models.py
@@ -31,6 +31,7 @@ class BaseFilters(BaseModel):
     document_set: list[str] | None = None
     time_cutoff: datetime | None = None
     tags: list[Tag] | None = None
+    prioritized_sources: list[str] | None = None  # Will be set from channel config
 
 
 class IndexFilters(BaseFilters):

--- a/backend/danswer/search/preprocessing/preprocessing.py
+++ b/backend/danswer/search/preprocessing/preprocessing.py
@@ -141,6 +141,7 @@ def retrieval_preprocessing(
         time_cutoff=preset_filters.time_cutoff or predicted_time_cutoff,
         tags=preset_filters.tags,  # Tags are never auto-extracted
         access_control_list=user_acl_filters,
+        prioritized_sources=preset_filters.prioritized_sources,  # Use prioritized_sources from filters
     )
 
     llm_chunk_filter = False

--- a/backend/danswer/server/manage/models.py
+++ b/backend/danswer/server/manage/models.py
@@ -108,6 +108,8 @@ class SlackBotConfigCreationRequest(BaseModel):
     answer_filters: list[AllowedAnswerFilters] = []
     # list of user emails
     follow_up_tags: list[str] | None = None
+    # List of source types to prioritize in search results
+    prioritized_sources: list[str] | None = None
     response_type: SlackBotResponseType
 
     @validator("answer_filters", pre=True)

--- a/backend/danswer/server/manage/slack_bot.py
+++ b/backend/danswer/server/manage/slack_bot.py
@@ -43,6 +43,7 @@ def _form_channel_config(
     )
     answer_filters = slack_bot_config_creation_request.answer_filters
     follow_up_tags = slack_bot_config_creation_request.follow_up_tags
+    prioritized_sources = slack_bot_config_creation_request.prioritized_sources
 
     if not raw_channel_names:
         raise HTTPException(
@@ -83,6 +84,8 @@ def _form_channel_config(
         channel_config["answer_filters"] = answer_filters
     if follow_up_tags is not None:
         channel_config["follow_up_tags"] = follow_up_tags
+    if prioritized_sources:
+        channel_config["prioritized_sources"] = prioritized_sources
 
     channel_config[
         "respond_to_bots"

--- a/web/src/app/admin/bot/SlackBotConfigCreationForm.tsx
+++ b/web/src/app/admin/bot/SlackBotConfigCreationForm.tsx
@@ -31,6 +31,8 @@ import { useRouter } from "next/navigation";
 import { Persona } from "../assistants/interfaces";
 import { useState } from "react";
 import { BookmarkIcon, RobotIcon } from "@/components/icons/icons";
+import { SourceIcon } from "@/components/SourceIcon";
+import { getSourceMetadata } from "@/lib/sources";
 
 export const SlackBotCreationForm = ({
   documentSets,
@@ -50,6 +52,15 @@ export const SlackBotCreationForm = ({
     : false;
   const [usingPersonas, setUsingPersonas] = useState(
     existingSlackBotUsesPersona
+  );
+
+  // Get unique sources from document sets
+  const availableSources = Array.from(
+    new Set(
+      documentSets.flatMap((docSet) =>
+        docSet.cc_pair_descriptors.map((desc) => desc.connector.source)
+      )
+    )
   );
 
   return (
@@ -95,6 +106,8 @@ export const SlackBotCreationForm = ({
                 ? existingSlackBotConfig.persona.id
                 : null,
             response_type: existingSlackBotConfig?.response_type || "citations",
+            prioritized_sources:
+              existingSlackBotConfig?.channel_config?.prioritized_sources || [],
           }}
           validationSchema={Yup.object().shape({
             channel_names: Yup.array().of(Yup.string()),
@@ -110,6 +123,7 @@ export const SlackBotCreationForm = ({
             follow_up_tags: Yup.array().of(Yup.string()),
             document_sets: Yup.array().of(Yup.number()),
             persona_id: Yup.number().nullable(),
+            prioritized_sources: Yup.array().of(Yup.string()),
           })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
@@ -162,7 +176,7 @@ export const SlackBotCreationForm = ({
             }
           }}
         >
-          {({ isSubmitting, values }) => (
+          {({ isSubmitting, values, setFieldValue }) => (
             <Form>
               <div className="px-6 pb-6">
                 <SectionHeader>The Basics</SectionHeader>
@@ -196,13 +210,12 @@ export const SlackBotCreationForm = ({
                       choose this option.
                       <br />
                       <br />
-                      If set to Quotes, Darwin will respond with a direct
-                      answer as well as with quotes pulled from the context
-                      documents to support that answer. Darwin will also
-                      give a list of relevant documents. Choose this option if
-                      you want a very detailed response AND/OR a list of
-                      relevant documents would be useful just in case the LLM
-                      missed anything.
+                      If set to Quotes, Darwin will respond with a direct answer
+                      as well as with quotes pulled from the context documents
+                      to support that answer. Darwin will also give a list of
+                      relevant documents. Choose this option if you want a very
+                      detailed response AND/OR a list of relevant documents
+                      would be useful just in case the LLM missed anything.
                     </>
                   }
                   options={[
@@ -289,8 +302,8 @@ export const SlackBotCreationForm = ({
                     Use either a Persona <b>or</b> Document Sets to control how
                     Darwin answers.
                   </Text>
-                  <Text>
-                    <ul className="list-disc mt-2 ml-4">
+                  <div className="mt-2">
+                    <ul className="list-disc ml-4">
                       <li>
                         You should use a Persona if you also want to customize
                         the prompt and retrieval settings.
@@ -300,7 +313,7 @@ export const SlackBotCreationForm = ({
                         which documents Darwin uses as references.
                       </li>
                     </ul>
-                  </Text>
+                  </div>
                   <Text className="mt-2">
                     <b>NOTE:</b> whichever tab you are when you submit the form
                     will be the one that is used. For example, if you are on the
@@ -389,6 +402,54 @@ export const SlackBotCreationForm = ({
                     </TabPanel>
                   </TabPanels>
                 </TabGroup>
+
+                <Divider />
+
+                <SectionHeader>Source Selection</SectionHeader>
+                <Text className="mb-2">
+                  Select the sources to emphasize in your search. Sources not
+                  selected will still be included, but fewer results from them
+                  may appear. If no sources are selected, Web and Salesforce KB
+                  articles are taken as default.
+                </Text>
+                <div className="mb-3 mt-2 flex gap-2 flex-wrap text-sm">
+                  {availableSources.map((source) => {
+                    const isSelected =
+                      values.prioritized_sources.includes(source);
+                    return (
+                      <div
+                        key={source}
+                        className={
+                          `
+                          px-3 
+                          py-1
+                          rounded-lg 
+                          border
+                          border-border 
+                          w-fit 
+                          flex 
+                          items-center
+                          gap-2
+                          cursor-pointer ` +
+                          (isSelected
+                            ? " bg-hover"
+                            : " bg-background hover:bg-hover-light")
+                        }
+                        onClick={() => {
+                          const newSources = isSelected
+                            ? values.prioritized_sources.filter(
+                                (s) => s !== source
+                              )
+                            : [...values.prioritized_sources, source];
+                          setFieldValue("prioritized_sources", newSources);
+                        }}
+                      >
+                        <SourceIcon sourceType={source} iconSize={16} />
+                        <span>{getSourceMetadata(source).displayName}</span>
+                      </div>
+                    );
+                  })}
+                </div>
 
                 <Divider />
 

--- a/web/src/app/admin/bot/lib.ts
+++ b/web/src/app/admin/bot/lib.ts
@@ -16,6 +16,7 @@ interface SlackBotConfigCreationRequest {
   respond_team_member_list: string[];
   respond_slack_group_list: string[];
   follow_up_tags?: string[];
+  prioritized_sources?: string[];
   usePersona: boolean;
   response_type: SlackBotResponseType;
 }
@@ -44,6 +45,7 @@ const buildRequestBodyFromCreationRequest = (
     respond_slack_group_list: creationRequest.respond_slack_group_list,
     answer_filters: buildFiltersFromCreationRequest(creationRequest),
     follow_up_tags: creationRequest.follow_up_tags?.filter((tag) => tag !== ""),
+    prioritized_sources: creationRequest.prioritized_sources,
     ...(creationRequest.usePersona
       ? { persona_id: creationRequest.persona_id }
       : { document_sets: creationRequest.document_sets }),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -543,6 +543,7 @@ export interface ChannelConfig {
   respond_slack_group_list?: string[];
   answer_filters?: AnswerFilterOption[];
   follow_up_tags?: string[];
+  prioritized_sources?: string[];
 }
 
 export type SlackBotResponseType = "quotes" | "citations";


### PR DESCRIPTION
Currently we give 10 hits to "web" and "sfkbarticles" for all queries by default.
Now we can configure(for each channel) the sources for which we want to give these extra 10 hits through the slack-bot-config in the UI.
If no such sources are specified for a channel, web and sfkbarticles will be taken as default.
<img width="1786" alt="Screenshot 2025-05-08 at 4 24 52 PM" src="https://github.com/user-attachments/assets/1c87b68c-7648-4662-8e5f-4ad8e1152d7f" />



