### PR TITLE
Auto-create Jira ticket for Slack messages with specific titles

### DIFF
--- a/backend/danswer/configs/danswerbot_configs.py
+++ b/backend/danswer/configs/danswerbot_configs.py
@@ -77,3 +77,8 @@ DANSWER_BOT_FEEDBACK_REMINDER = int(
 DANSWER_BOT_REPHRASE_MESSAGE = (
     os.environ.get("DANSWER_BOT_REPHRASE_MESSAGE", "").lower() == "true"
 )
+
+# JIRA Configuration
+JIRA_SERVER_URL = os.getenv("JIRA_SERVER_URL", "")
+JIRA_EMAIL = os.getenv("JIRA_EMAIL", "")
+JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN", "")

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -35,10 +35,12 @@ from danswer.danswerbot.slack.blocks import get_feedback_reminder_blocks
 from danswer.danswerbot.slack.blocks import get_restate_blocks
 from danswer.danswerbot.slack.constants import SLACK_CHANNEL_ID
 from danswer.danswerbot.slack.models import SlackMessageInfo
+from danswer.danswerbot.slack.tools.jira_tools import create_jira_ticket
 from danswer.danswerbot.slack.tools.opsgenie import get_dri_on_call
 from danswer.danswerbot.slack.utils import ChannelIdAdapter
 from danswer.danswerbot.slack.utils import fetch_userids_from_emails
 from danswer.danswerbot.slack.utils import fetch_userids_from_groups
+from danswer.danswerbot.slack.utils import get_slack_message_link
 from danswer.danswerbot.slack.utils import respond_in_thread
 from danswer.danswerbot.slack.utils import slack_usage_report
 from danswer.danswerbot.slack.utils import SlackRateLimiter
@@ -226,6 +228,55 @@ def handle_message(
     is_bot_msg = message_info.is_bot_msg
     is_bot_dm = message_info.is_bot_dm
     persona_name = None
+
+    # Check if channel config has JIRA integration enabled and title filter
+    if channel_config and channel_config.channel_config:
+        channel_conf = channel_config.channel_config
+        jira_config = channel_conf.get("jira_config", {})
+        jira_enabled = jira_config.get("enable_jira_integration", False)
+        jira_title_filter = channel_conf.get("jira_title_filter", [])
+
+        if jira_enabled and jira_title_filter and sender_id:
+            # Get user info to check title
+            try:
+                user_info = client.users_info(user=sender_id)
+                user_title = (
+                    user_info["user"].get("profile", {}).get("title", "").lower()
+                )
+
+                if user_title in [title.lower() for title in jira_title_filter]:
+                    # Create JIRA ticket
+                    slack_message_link = get_slack_message_link(
+                        channel=channel,
+                        message_ts=message_ts_to_respond_to,
+                        client=client,
+                    )
+
+                    # Get JIRA configuration from channel config
+                    project_key = jira_config.get("project_key")
+                    issue_type = jira_config.get("issue_type", "Task")
+                    component = jira_config.get("component")
+
+                    jira_ticket_url = create_jira_ticket(
+                        title=f"Slack Query from {user_info['user']['real_name']}",
+                        description=f"Original message: {messages[-1].message}",
+                        slack_message_link=slack_message_link,
+                        project_key=project_key,
+                        issue_type=issue_type,
+                        component=component,
+                    )
+
+                    if jira_ticket_url:
+                        logger.info(f"Created JIRA ticket: {jira_ticket_url}")
+                        # Send acknowledgement with JIRA ticket link
+                        respond_in_thread(
+                            client=client,
+                            channel=channel,
+                            text=f"I've created a JIRA ticket for your query. You can track it here: {jira_ticket_url}",
+                            thread_ts=message_ts_to_respond_to,
+                        )
+            except Exception as e:
+                logger.error(f"Failed to process JIRA integration: {str(e)}")
 
     if channel_name is None:
         with Session(get_sqlalchemy_engine()) as db_session:

--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -272,7 +272,7 @@ def handle_message(
                         respond_in_thread(
                             client=client,
                             channel=channel,
-                            text=f"I've created a JIRA ticket for your query. You can track it here: {jira_ticket_url}",
+                            text=f"Tracking Jira ticket: {jira_ticket_url}",
                             thread_ts=message_ts_to_respond_to,
                         )
             except Exception as e:

--- a/backend/danswer/danswerbot/slack/tools/jira_tools.py
+++ b/backend/danswer/danswerbot/slack/tools/jira_tools.py
@@ -1,0 +1,67 @@
+import logging
+from typing import Optional
+
+from jira import JIRA
+
+from danswer.configs.danswerbot_configs import JIRA_API_TOKEN
+from danswer.configs.danswerbot_configs import JIRA_EMAIL
+from danswer.configs.danswerbot_configs import JIRA_SERVER_URL
+
+logger = logging.getLogger(__name__)
+
+
+def create_jira_ticket(
+    title: str,
+    description: str,
+    slack_message_link: str,
+    project_key: str,
+    issue_type: str,
+    component: str | None = None,
+) -> Optional[str]:
+    """
+    Create a JIRA ticket with the given details
+
+    Args:
+        title: Title of the JIRA ticket
+        description: Description of the issue
+        slack_message_link: Link to the Slack message that triggered this ticket
+        project_key: JIRA project key to create the ticket in
+        issue_type: Type of JIRA issue (default: Task)
+        component: Component to assign the ticket to (optional)
+
+    Returns:
+        str: URL of the created JIRA ticket if successful, None otherwise
+    """
+    try:
+        # Initialize JIRA client with email and API token
+        jira = JIRA(server=JIRA_SERVER_URL, basic_auth=(JIRA_EMAIL, JIRA_API_TOKEN))
+
+        # Create the issue
+        issue_dict = {
+            "project": {"key": project_key},
+            "summary": title,
+            "description": f"{description}\n\nRelated Slack Message: {slack_message_link}",
+            "issuetype": {"name": issue_type},
+        }
+
+        # Only add component if specified
+        if component:
+            issue_dict["components"] = [{"name": component}]
+
+        new_issue = jira.create_issue(fields=issue_dict)
+        return f"{JIRA_SERVER_URL}/browse/{new_issue.key}"
+
+    except Exception as e:
+        logger.error(f"Failed to create JIRA ticket: {str(e)}")
+        return None
+
+
+if __name__ == "__main__":
+    create_jira_ticket(
+        title="Test Ticket - 3",
+        description="This is a test ticket",
+        slack_message_link="https://example.com/slack-message",
+        project_key="ABC",
+        issue_type="Task",
+        component="abc",
+    )

--- a/backend/danswer/danswerbot/slack/utils.py
+++ b/backend/danswer/danswerbot/slack/utils.py
@@ -539,3 +539,27 @@ def format_messages_for_summary(
         formatted_msg = f"[{timestamp}] {user_name}: {text}"
         formatted_messages.append(formatted_msg)
     return "\n\n".join(formatted_messages)
+
+
+def get_slack_message_link(channel: str, message_ts: str, client: WebClient) -> str:
+    """
+    Get a direct link to a Slack message
+
+    Args:
+        channel: Channel ID where the message is located
+        message_ts: Timestamp of the message
+        client: Slack WebClient instance
+
+    Returns:
+        str: URL to the Slack message
+    """
+    try:
+        response = client.chat_getPermalink(channel=channel, message_ts=message_ts)
+        if response["ok"]:
+            return response["permalink"]
+        else:
+            logger.error(f"Failed to get permalink: {response.get('error')}")
+            return ""
+    except Exception as e:
+        logger.error(f"Failed to get Slack message link: {str(e)}")
+        return ""

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -1087,6 +1087,10 @@ class ChannelConfig(TypedDict):
     prioritized_sources: NotRequired[list[str]]
     # OpsGenie schedule name for DRI on-call
     opsgenie_schedule: NotRequired[str]
+    # JIRA title filter for creating tickets
+    jira_title_filter: NotRequired[list[str]]
+    # JIRA integration settings
+    jira_config: NotRequired[dict[str, Any]]  # Contains all JIRA related settings
 
 
 class SlackBotResponseType(str, PyEnum):

--- a/backend/danswer/server/manage/models.py
+++ b/backend/danswer/server/manage/models.py
@@ -111,6 +111,8 @@ class SlackBotConfigCreationRequest(BaseModel):
     # List of source types to prioritize in search results
     prioritized_sources: list[str] | None = None
     opsgenie_schedule: str | None = None
+    jira_config: dict[str, Any] | None = None
+    jira_title_filter: list[str] | None = None
     response_type: SlackBotResponseType
 
     @validator("answer_filters", pre=True)

--- a/backend/danswer/server/manage/slack_bot.py
+++ b/backend/danswer/server/manage/slack_bot.py
@@ -45,6 +45,8 @@ def _form_channel_config(
     follow_up_tags = slack_bot_config_creation_request.follow_up_tags
     prioritized_sources = slack_bot_config_creation_request.prioritized_sources
     opsgenie_schedule = slack_bot_config_creation_request.opsgenie_schedule
+    jira_config = slack_bot_config_creation_request.jira_config
+    jira_title_filter = slack_bot_config_creation_request.jira_title_filter
 
     if not raw_channel_names:
         raise HTTPException(
@@ -89,6 +91,10 @@ def _form_channel_config(
         channel_config["prioritized_sources"] = prioritized_sources
     if opsgenie_schedule:
         channel_config["opsgenie_schedule"] = opsgenie_schedule
+    if jira_config:
+        channel_config["jira_config"] = jira_config
+    if jira_title_filter:
+        channel_config["jira_title_filter"] = jira_title_filter
 
     channel_config[
         "respond_to_bots"

--- a/web/src/app/admin/bot/SlackBotConfigCreationForm.tsx
+++ b/web/src/app/admin/bot/SlackBotConfigCreationForm.tsx
@@ -111,6 +111,15 @@ export const SlackBotCreationForm = ({
             response_type: existingSlackBotConfig?.response_type || "citations",
             prioritized_sources:
               existingSlackBotConfig?.channel_config?.prioritized_sources || [],
+            jira_config: existingSlackBotConfig?.channel_config
+              ?.jira_config || {
+              enable_jira_integration: false,
+              project_key: "",
+              issue_type: "",
+              component: "",
+            },
+            jira_title_filter:
+              existingSlackBotConfig?.channel_config?.jira_title_filter || [],
           }}
           validationSchema={Yup.object().shape({
             channel_names: Yup.array().of(Yup.string()),
@@ -128,6 +137,51 @@ export const SlackBotCreationForm = ({
             document_sets: Yup.array().of(Yup.number()),
             persona_id: Yup.number().nullable(),
             prioritized_sources: Yup.array().of(Yup.string()),
+            jira_config: Yup.object().shape({
+              enable_jira_integration: Yup.boolean().required(),
+              project_key: Yup.string().when("enable_jira_integration", {
+                is: true,
+                then: (schema) =>
+                  schema.required(
+                    "Project key is required when JIRA integration is enabled"
+                  ),
+                otherwise: (schema) => schema.notRequired(),
+              }),
+              issue_type: Yup.string().when("enable_jira_integration", {
+                is: true,
+                then: (schema) =>
+                  schema.required(
+                    "Issue type is required when JIRA integration is enabled"
+                  ),
+                otherwise: (schema) => schema.notRequired(),
+              }),
+              component: Yup.string().notRequired(),
+            }),
+            jira_title_filter: Yup.array()
+              .of(Yup.string().required("Title filter cannot be empty"))
+              .when(["jira_config.enable_jira_integration"], {
+                is: (enableJira: boolean) => enableJira,
+                then: (schema) =>
+                  schema
+                    .min(
+                      1,
+                      "At least one title filter is required when JIRA integration is enabled"
+                    )
+                    .test(
+                      "non-empty-strings",
+                      "Title filters cannot be empty",
+                      (value) => {
+                        if (!value || !Array.isArray(value)) return false;
+                        return value.every(
+                          (title) =>
+                            title &&
+                            typeof title === "string" &&
+                            title.trim().length > 0
+                        );
+                      }
+                    ),
+                otherwise: (schema) => schema.notRequired(),
+              }),
           })}
           onSubmit={async (values, formikHelpers) => {
             formikHelpers.setSubmitting(true);
@@ -148,6 +202,14 @@ export const SlackBotCreationForm = ({
               ),
               usePersona: usingPersonas,
               opsgenie_schedule: values.opsgenie_schedule || undefined,
+              jira_config: {
+                enable_jira_integration:
+                  values.jira_config.enable_jira_integration ?? false,
+                project_key: values.jira_config.project_key ?? "",
+                issue_type: values.jira_config.issue_type ?? "",
+                component: values.jira_config.component?.trim() || undefined,
+              },
+              jira_title_filter: values.jira_title_filter ?? [],
             };
             if (!cleanedValues.still_need_help_enabled) {
               cleanedValues.follow_up_tags = undefined;
@@ -413,6 +475,56 @@ export const SlackBotCreationForm = ({
                     </TabPanel>
                   </TabPanels>
                 </TabGroup>
+
+                <Divider />
+
+                <SectionHeader>JIRA Integration</SectionHeader>
+
+                <BooleanFormField
+                  name="jira_config.enable_jira_integration"
+                  label="Enable JIRA Integration"
+                  subtext="If enabled, creates JIRA tickets for messages from users with specific titles"
+                />
+
+                {values.jira_config.enable_jira_integration && (
+                  <>
+                    <TextArrayField
+                      name="jira_title_filter"
+                      label="User Titles to Create JIRA Tickets For"
+                      values={values}
+                      subtext={
+                        <div>
+                          List of user titles that should trigger JIRA ticket
+                          creation. For example, &apos;Senior Software
+                          Engineer&apos;, &apos;Software Engineer II&apos;, etc.
+                          <br />
+                          <br />
+                          When a user with any of these titles sends a message,
+                          a JIRA ticket will be created with the message content
+                          and a link to the Slack message.
+                        </div>
+                      }
+                    />
+
+                    <TextFormField
+                      name="jira_config.project_key"
+                      label="JIRA Project Key"
+                      subtext="The key of the JIRA project where tickets will be created"
+                    />
+
+                    <TextFormField
+                      name="jira_config.issue_type"
+                      label="JIRA Issue Type"
+                      subtext="The type of issue to create (e.g. Bug, Task, Story)"
+                    />
+
+                    <TextFormField
+                      name="jira_config.component"
+                      label="JIRA Component"
+                      subtext="The component to assign the issue to"
+                    />
+                  </>
+                )}
 
                 <Divider />
 

--- a/web/src/app/admin/bot/lib.ts
+++ b/web/src/app/admin/bot/lib.ts
@@ -18,6 +18,13 @@ interface SlackBotConfigCreationRequest {
   follow_up_tags?: string[];
   prioritized_sources?: string[];
   opsgenie_schedule?: string;
+  jira_config?: {
+    enable_jira_integration: boolean;
+    project_key: string;
+    issue_type: string;
+    component?: string;
+  };
+  jira_title_filter?: string[];
   usePersona: boolean;
   response_type: SlackBotResponseType;
 }
@@ -48,6 +55,8 @@ const buildRequestBodyFromCreationRequest = (
     follow_up_tags: creationRequest.follow_up_tags?.filter((tag) => tag !== ""),
     prioritized_sources: creationRequest.prioritized_sources,
     opsgenie_schedule: creationRequest.opsgenie_schedule,
+    jira_config: creationRequest.jira_config,
+    jira_title_filter: creationRequest.jira_title_filter,
     ...(creationRequest.usePersona
       ? { persona_id: creationRequest.persona_id }
       : { document_sets: creationRequest.document_sets }),

--- a/web/src/components/admin/connectors/Field.tsx
+++ b/web/src/components/admin/connectors/Field.tsx
@@ -302,6 +302,12 @@ export function TextArrayField<T extends Yup.AnyObject>({
             >
               Add New
             </Button>
+
+            <ErrorMessage
+              name={name}
+              component="div"
+              className="text-error text-sm mt-1"
+            />
           </div>
         )}
       />

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -545,6 +545,13 @@ export interface ChannelConfig {
   follow_up_tags?: string[];
   prioritized_sources?: string[];
   opsgenie_schedule?: string;
+  jira_title_filter?: string[];
+  jira_config?: {
+    enable_jira_integration?: boolean;
+    project_key?: string;
+    issue_type?: string;
+    component?: string;
+  };
 }
 
 export type SlackBotResponseType = "quotes" | "citations";


### PR DESCRIPTION
UI addition :
<img width="1400" alt="Screenshot 2025-06-26 at 5 39 15 PM" src="https://github.com/user-attachments/assets/948917d1-7535-43c4-bd4b-c1054713bac1" />

The user will see a message like this:
<img width="575" alt="Screenshot 2025-06-26 at 5 20 52 PM" src="https://github.com/user-attachments/assets/1d06bc08-dc79-4d2c-9288-305ed11d71c7" />


[Example Ticket](https://uipath.atlassian.net/browse/ENGCE-48567)
