### PR TITLE
Handle rate limit from llm-gateway

### DIFF
--- a/backend/danswer/llm/custom_llm.py
+++ b/backend/danswer/llm/custom_llm.py
@@ -125,7 +125,8 @@ class CustomModelServer(LLM):
             "Content-Type": "application/json",
             "X-UiPath-LlmGateway-RequestedFeature": "ChatWithAssistant",
             "X-UiPath-LlmGateway-RequestingFeature": "ChatWithAssistant",
-            "X-UiPath-LlmGateway-RequestingProduct": "hackathon",
+            "X-UiPath-LlmGateway-RequestingProduct": "darwin",
+            "X-UiPath-LlmGateway-TimeoutSeconds": "60",
             "Authorization": "Bearer " + self.token,
         }
 


### PR DESCRIPTION
To address rate-limit from the llm-gateway, we are doing two things:
1. Change the `X-UiPath-LlmGateway-RequestingProduct` in our call to llm gateway from `hackathon` to `darwin` . 
2. Add `X-UIPATH-LLMGateway-TimeoutSeconds`  header(with 60 secs value) as 429 can also be due to timeout.