### PR TITLE
Update JIRA Api version

### DIFF
--- a/backend/danswer/connectors/danswer_jira/connector.py
+++ b/backend/danswer/connectors/danswer_jira/connector.py
@@ -28,7 +28,7 @@ from danswer.utils.logger import setup_logger
 
 logger = setup_logger()
 
-JIRA_API_VERSION = os.environ.get("JIRA_API_VERSION") or "2"
+JIRA_API_VERSION = os.environ.get("JIRA_API_VERSION") or "3"
 _JIRA_FULL_PAGE_SIZE = 50
 
 

--- a/backend/danswer/connectors/danswer_jira/utils.py
+++ b/backend/danswer/connectors/danswer_jira/utils.py
@@ -13,7 +13,7 @@ from danswer.utils.logger import setup_logger
 
 logger = setup_logger()
 
-JIRA_API_VERSION = os.environ.get("JIRA_API_VERSION") or "2"
+JIRA_API_VERSION = os.environ.get("JIRA_API_VERSION") or "3"
 
 
 def best_effort_basic_expert_info(obj: Any) -> BasicExpertInfo | None:

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -23,7 +23,7 @@ httpcore==0.16.3
 httpx[http2]==0.23.3
 httpx-oauth==0.11.2
 huggingface-hub==0.20.1
-jira==3.5.1
+jira==3.10.5
 jsonref==1.1.0
 langchain==0.1.17
 langchain-community==0.0.36


### PR DESCRIPTION
The Jira connector was failing to scrape issues with HTTP 410 errors. Atlassian has permanently removed the Jira REST API v2 endpoints Error:
```
jira.exceptions.JIRAError: JiraError HTTP 410 url: https://uipath.atlassian.net/rest/api/2/search
text: The requested API has been removed. Please migrate to the /rest/api/3/search/jql API.
```
This PR updates the API version to v3
