### PR TITLE
Change prompt to include URLs in response

### DIFF
--- a/backend/danswer/prompts/chat_prompts.py
+++ b/backend/danswer/prompts/chat_prompts.py
@@ -3,7 +3,8 @@ from danswer.prompts.constants import QUESTION_PAT
 
 REQUIRE_CITATION_STATEMENT = """
 CRUCIAL: Cite relevant statements INLINE using the format [1], [2], [3], etc to reference the document number, \
-DO NOT provide a reference section at the end and DO NOT provide any links following the citations.
+DO NOT provide a reference section at the end. If the source document contains a URL as part of the answer, \
+include that URL in your response.
 """.rstrip()
 
 NO_CITATION_STATEMENT = """


### PR DESCRIPTION
Darwin is skipping URLs from the answer due to this previous prompt. 
The previous prompt instruction "DO NOT provide any links following the citations" was too broad, causing the LLM to remove all URLs from responses

Question: What is the product scope DOC for Robot

Response before this change: The product scope document for Robot is the "Robot Support Scope Document" [1]
Current response: The product scope document for Robot is https://uipath.atlassian.net/wiki/spaces/GPSSUP/pages....