### PR TITLE
fix: truncate persona option text to 75 chars for Slack views.open limit

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -370,7 +370,7 @@ def handle_message(
                     {
                         "text": {
                             "type": "plain_text",
-                            "text": f"{persona.name} • {persona.description}",
+                            "text": f"{persona.name} • {persona.description}"[:75],
                             "emoji": True,
                         },
                         "value": str(persona.id),


### PR DESCRIPTION
### Problem
The /personas slash command in the Slack bot was failing with:


Error sending select menu: The request to the Slack API failed. (url: https://www.slack.com/api/views.open)
'error': 'invalid_arguments'
'[ERROR] must be less than 76 characters [json-pointer:/view/blocks/0/element/options/27/text/text]'
One or more personas had a combined name • description string exceeding Slack's 75-character limit for plain_text option labels in static_select modals.

### Fix
Truncate the option label f"{persona.name} • {persona.description}" to 75 characters before passing it to views.open.

### Root Cause
Slack's Block Kit enforces a hard 75-character limit on plain_text option text in static_select elements. Persona option 27 (0-indexed) was exceeding this limit, causing the entire modal to fail.