### PR TITLE
fix(slack): resolve dead product.slack.com citation links

### DIFF
--- a/backend/danswer/connectors/slack/connector.py
+++ b/backend/danswer/connectors/slack/connector.py
@@ -27,6 +27,7 @@ from danswer.connectors.slack.utils import get_message_link
 from danswer.connectors.slack.utils import make_slack_api_call_logged
 from danswer.connectors.slack.utils import make_slack_api_call_paginated
 from danswer.connectors.slack.utils import make_slack_api_rate_limited
+from danswer.connectors.slack.utils import resolve_workspace_subdomain
 from danswer.connectors.slack.utils import SlackTextCleaner
 from danswer.utils.logger import setup_logger
 
@@ -323,6 +324,11 @@ def get_all_docs(
             client=client, channel=channel, oldest=oldest, latest=latest
         )
 
+        # Resolve the channel's true workspace subdomain (Grid-safe) lazily on
+        # the first message, then reuse it for every thread in the channel — one
+        # chat.getPermalink call per channel rather than per message.
+        channel_workspace: str | None = None
+
         seen_thread_ts: set[str] = set()
         for message_batch in channel_message_batches:
             for message in message_batch:
@@ -344,9 +350,16 @@ def get_all_docs(
                     filtered_thread = [message]
 
                 if filtered_thread:
+                    if channel_workspace is None:
+                        channel_workspace = resolve_workspace_subdomain(
+                            client=client,
+                            channel_id=channel["id"],
+                            message_ts=filtered_thread[0]["ts"],
+                            fallback=workspace,
+                        )
                     channel_docs += 1
                     yield thread_to_doc(
-                        workspace=workspace,
+                        workspace=channel_workspace,
                         channel=channel,
                         thread=filtered_thread,
                         slack_cleaner=slack_cleaner,

--- a/backend/danswer/connectors/slack/utils.py
+++ b/backend/danswer/connectors/slack/utils.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 from functools import wraps
 from typing import Any
 from typing import cast
+from urllib.parse import urlparse
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -17,6 +18,23 @@ logger = setup_logger()
 
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
+
+# Mis-stored Slack workspace subdomains -> their correct URL subdomain.
+# Historically some connectors were configured with the workspace *display name*
+# ("Product") instead of the URL subdomain ("uipath-product"), so their stored
+# permalinks point at the dead host `product.slack.com`. Keys are matched case-
+# and whitespace-insensitively, so this covers both "Product" and "Product ".
+# This is an explicit allow-map on purpose: only listed subdomains are rewritten,
+# so genuinely different workspaces (uipath-customer-ops, uipath-marketing, ...)
+# and links already on a correct host are left untouched. Add an entry here if a
+# new mis-configured workspace surfaces.
+_SLACK_SUBDOMAIN_FIXES = {
+    "product": "uipath-product",
+}
+
+# Captures the subdomain in the `//<sub>.slack.com` portion of a permalink.
+# `[^/]*?` is non-greedy and tolerates a stray space ("Product .slack.com").
+_SLACK_HOST_RE = re.compile(r"(//)([^/]*?)(\.slack\.com)", re.IGNORECASE)
 
 
 def get_message_link(
@@ -32,6 +50,62 @@ def get_message_link(
         f"https://{workspace}.slack.com/archives/{channel_id}/p{message_ts_without_dot}"
         + (f"?thread_ts={thread_ts}" if thread_ts else "")
     )
+
+
+def normalize_slack_link(url: str) -> str:
+    """Rewrite a mis-stored Slack workspace subdomain to the canonical one.
+
+    Existing indexed docs carry links built from a mis-configured workspace
+    ("Product" -> dead `product.slack.com`). Retrieval reads every citation
+    link back through here, so chat / search / Slack-bot citations all resolve
+    to the real workspace without re-indexing or a data migration. Only the
+    subdomains in `_SLACK_SUBDOMAIN_FIXES` are rewritten; a link on the canonical
+    host, or on a genuinely different workspace, is returned unchanged."""
+    if not url or ".slack.com" not in url.lower():
+        return url
+
+    def _fix(match: "re.Match[str]") -> str:
+        subdomain = match.group(2).strip().lower()
+        canonical = _SLACK_SUBDOMAIN_FIXES.get(subdomain)
+        if canonical is not None:
+            return f"{match.group(1)}{canonical}{match.group(3)}"
+        return match.group(0)
+
+    return _SLACK_HOST_RE.sub(_fix, url, count=1)
+
+
+def resolve_workspace_subdomain(
+    client: WebClient, channel_id: str, message_ts: str, fallback: str
+) -> str:
+    """Ask Slack for the authoritative workspace subdomain of a channel.
+
+    `chat.getPermalink` returns the real permalink for a message, with the
+    correct `<sub>.slack.com` host even under Enterprise Grid (where a single
+    bot can see channels that live in different workspaces, each with its own
+    URL). We resolve this ONCE per channel and reuse it, so the connector no
+    longer depends on a hand-typed `workspace` config being right. Falls back to
+    `fallback` (the configured workspace) if the call fails."""
+    try:
+        resp = client.chat_getPermalink(channel=channel_id, message_ts=message_ts)
+        permalink = cast(str, resp.get("permalink") or "")
+        host = urlparse(permalink).netloc.lower()
+        if host.endswith(".slack.com"):
+            subdomain = host[: -len(".slack.com")]
+            if subdomain:
+                return subdomain
+    except SlackApiError as e:
+        logger.warning(
+            "chat.getPermalink failed for channel %s (%s); "
+            "falling back to configured workspace '%s'",
+            channel_id,
+            e.response.get("error"),
+            fallback,
+        )
+    except Exception as e:
+        logger.warning(
+            "could not resolve workspace subdomain for channel %s: %s", channel_id, e
+        )
+    return fallback
 
 
 def make_slack_api_call_logged(

--- a/backend/danswer/connectors/slack/utils.py
+++ b/backend/danswer/connectors/slack/utils.py
@@ -86,7 +86,11 @@ def resolve_workspace_subdomain(
     longer depends on a hand-typed `workspace` config being right. Falls back to
     `fallback` (the configured workspace) if the call fails."""
     try:
-        resp = client.chat_getPermalink(channel=channel_id, message_ts=message_ts)
+        # Same rate-limit + logging wrapping as every other Slack call in the
+        # connector, so a 429 retries (with Retry-After) instead of falling back.
+        resp = make_slack_api_rate_limited(
+            make_slack_api_call_logged(client.chat_getPermalink)
+        )(channel=channel_id, message_ts=message_ts)
         permalink = cast(str, resp.get("permalink") or "")
         host = urlparse(permalink).netloc.lower()
         if host.endswith(".slack.com"):

--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -59,6 +59,7 @@ from danswer.configs.model_configs import SEARCH_DISTANCE_CUTOFF
 from danswer.connectors.cross_connector_utils.miscellaneous_utils import (
     get_experts_stores_representations,
 )
+from danswer.connectors.slack.utils import normalize_slack_link
 from danswer.document_index.document_index_utils import get_uuid_from_chunk
 from danswer.document_index.interfaces import DocumentIndex
 from danswer.document_index.interfaces import DocumentInsertionRecord
@@ -681,8 +682,12 @@ def _vespa_hit_to_inference_chunk(hit: dict[str, Any]) -> InferenceChunk:
     source_links_dict_unprocessed = (
         json.loads(source_links) if isinstance(source_links, str) else source_links
     )
+    # Slack: historical docs were indexed with a mis-configured workspace, so
+    # their permalinks point at a dead host. Rewrite to the canonical workspace
+    # at read time so every citation (chat / search / Slack bot) resolves.
+    is_slack = str(fields.get(SOURCE_TYPE, "")).lower() == "slack"
     source_links_dict = {
-        int(k): v
+        int(k): (normalize_slack_link(v) if is_slack else v)
         for k, v in cast(dict[str, str], source_links_dict_unprocessed).items()
     }
 

--- a/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
+++ b/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
@@ -5,15 +5,22 @@ from danswer.connectors.slack.utils import normalize_slack_link
 from danswer.connectors.slack.utils import resolve_workspace_subdomain
 
 
+class _FakeResp(dict):
+    """Minimal stand-in for slack_sdk's SlackResponse (dict-like + validate())."""
+
+    def validate(self) -> "_FakeResp":
+        return self
+
+
 class _FakeClient:
     def __init__(self, permalink: str | None = None, error: str | None = None):
         self._permalink = permalink
         self._error = error
 
-    def chat_getPermalink(self, channel: str, message_ts: str) -> dict:
+    def chat_getPermalink(self, channel: str, message_ts: str) -> _FakeResp:
         if self._error is not None:
             raise SlackApiError(self._error, {"ok": False, "error": self._error})
-        return {"ok": True, "permalink": self._permalink}
+        return _FakeResp({"ok": True, "permalink": self._permalink})
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
+++ b/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
@@ -1,0 +1,103 @@
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from danswer.connectors.slack.utils import normalize_slack_link
+from danswer.connectors.slack.utils import resolve_workspace_subdomain
+
+
+class _FakeClient:
+    def __init__(self, permalink: str | None = None, error: str | None = None):
+        self._permalink = permalink
+        self._error = error
+
+    def chat_getPermalink(self, channel: str, message_ts: str) -> dict:
+        if self._error is not None:
+            raise SlackApiError(self._error, {"ok": False, "error": self._error})
+        return {"ok": True, "permalink": self._permalink}
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # The bug: workspace display name "Product" -> dead product.slack.com.
+        (
+            "https://Product.slack.com/archives/C02EF2C5KS8/p1712595481616829",
+            "https://uipath-product.slack.com/archives/C02EF2C5KS8/p1712595481616829",
+        ),
+        # Trailing space variant seen in the data ("Product ").
+        (
+            "https://Product .slack.com/archives/C02/p1?thread_ts=1712595481.616829",
+            "https://uipath-product.slack.com/archives/C02/p1?thread_ts=1712595481.616829",
+        ),
+        # Case-insensitive match.
+        (
+            "https://product.slack.com/archives/C02/p1",
+            "https://uipath-product.slack.com/archives/C02/p1",
+        ),
+        # Idempotent: already-canonical link is untouched.
+        (
+            "https://uipath-product.slack.com/archives/C02/p1",
+            "https://uipath-product.slack.com/archives/C02/p1",
+        ),
+        # Genuinely different workspaces must NOT be rewritten.
+        (
+            "https://uipath-customer-ops.slack.com/archives/C99/p2",
+            "https://uipath-customer-ops.slack.com/archives/C99/p2",
+        ),
+        (
+            "https://uipath-marketing.slack.com/archives/C99/p2",
+            "https://uipath-marketing.slack.com/archives/C99/p2",
+        ),
+        # Non-Slack links pass through unchanged (even if a path says "product").
+        (
+            "https://docs.uipath.com/product/latest",
+            "https://docs.uipath.com/product/latest",
+        ),
+        # Only the host is rewritten, not a matching path segment.
+        (
+            "https://Product.slack.com/archives/product/p1",
+            "https://uipath-product.slack.com/archives/product/p1",
+        ),
+    ],
+)
+def test_normalize_slack_link(raw: str, expected: str) -> None:
+    assert normalize_slack_link(raw) == expected
+
+
+def test_normalize_slack_link_empty() -> None:
+    assert normalize_slack_link("") == ""
+
+
+def test_resolve_workspace_subdomain_from_permalink() -> None:
+    client = _FakeClient(
+        permalink="https://uipath-product.slack.com/archives/C02/p1712595481616829"
+    )
+    assert (
+        resolve_workspace_subdomain(client, "C02", "1712595481.616829", fallback="X")  # type: ignore[arg-type]
+        == "uipath-product"
+    )
+
+
+def test_resolve_workspace_subdomain_other_workspace() -> None:
+    client = _FakeClient(
+        permalink="https://uipath-customer-ops.slack.com/archives/C99/p1"
+    )
+    assert (
+        resolve_workspace_subdomain(client, "C99", "1.1", fallback="X")  # type: ignore[arg-type]
+        == "uipath-customer-ops"
+    )
+
+
+@pytest.mark.parametrize(
+    "client",
+    [
+        _FakeClient(error="channel_not_found"),  # API error -> fallback
+        _FakeClient(permalink=""),  # empty permalink -> fallback
+        _FakeClient(permalink="https://example.com/not-slack"),  # non-slack -> fallback
+    ],
+)
+def test_resolve_workspace_subdomain_falls_back(client: _FakeClient) -> None:
+    assert (
+        resolve_workspace_subdomain(client, "C1", "1.1", fallback="uipath-product")  # type: ignore[arg-type]
+        == "uipath-product"
+    )

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -30,7 +30,7 @@ namespace: darwin
 images:
   - name: danswer-backend
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-backend
-    newTag: vha-217
+    newTag: vha-218
   - name: danswer-web-server
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-web-server
     newTag: vha-116

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -30,7 +30,7 @@ namespace: darwin
 images:
   - name: danswer-backend
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-backend
-    newTag: vha-216
+    newTag: vha-217
   - name: danswer-web-server
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-web-server
     newTag: vha-116


### PR DESCRIPTION
## Problem

Clicking a Slack citation in Darwin opened `product.slack.com`, a dead host — users couldn't reach the message ([reported in #help-darwin](https://uipath-product.slack.com/archives/C077AFEGCKZ/p1784278536862749)).

Root cause is **data, not the format string**: Slack connectors were configured with the workspace *display name* (`"Product"`, plus a `"Product "` trailing-space variant) instead of the URL subdomain (`uipath-product`), so every indexed permalink was built as `https://Product.slack.com/...` → browsers lowercase it → dead `product.slack.com`.

**Blast radius:** ~320,670 docs across 913 channels. Verified (via `chat.getPermalink` on a 110-channel sample) that **all** indexed Slack content genuinely lives in the `uipath-product` workspace.

## Fix — two layers, no re-index / data migration

**Read-time (fixes all existing docs).** `normalize_slack_link()` rewrites the known-bad `product` subdomain → `uipath-product` via an explicit allow-map (case/whitespace-insensitive), applied once in `_vespa_hit_to_inference_chunk`. Every citation — chat, search, and the Slack bot — derives its link from `source_links`, so this single choke point covers all three. Genuinely different workspaces (`uipath-customer-ops`, `uipath-marketing`, …) and already-correct links are left untouched.

**Index-time (prevents recurrence for any workspace).** `get_all_docs` now resolves each channel's true workspace subdomain once via `chat.getPermalink` (correct even under Enterprise Grid, where a bot spans workspaces), caching per channel. The hand-typed `workspace` config is now only a fallback. The call goes through the connector's standard `make_slack_api_rate_limited` wrapper.

## Validation (read-only, against prod)

- Normalized link **== Slack's authoritative `chat.getPermalink`** for **40/40** sampled docs (host + path).
- Real `keyword_retrieval` path returned **10/10** `uipath-product` links.
- 14 unit tests (allow-map edge cases + resolver success/fallback); mypy + pre-commit clean.

## Deploy status

Backend deployed to prod as **`vha-217`** and validated live (retrieval on the shipped code → 10/10 normalized). The rate-limit hardening (`86041d9b`) is index-time-only and will ship in the next backend build.

## Follow-ups (not in this PR)

- Optional: backfill Postgres `document.link` + Vespa `source_links`, then retire the read-time shim.
- The admin document view (`server/manage/administrative.py`) serves Postgres `document.link` directly, so it still shows the old host until a backfill — not in the user-facing citation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
