### PR TITLE
Self-serve team onboarding for Darwin

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_onboarding_help_thread_ts.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_onboarding_help_thread_ts.py
@@ -1,0 +1,29 @@
+"""onboarding_request.help_thread_ts
+
+Revision ID: a1b2c3d4e5f6
+Revises: c40f5a073fc2
+Create Date: 2026-07-18 00:00:00.000000
+
+Adds help_thread_ts: the Slack ts of the customer-facing root message posted on
+submit, so lifecycle updates (approved / complete / failed) can be posted as
+replies in that thread. Additive nullable column — no impact on existing rows.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "c40f5a073fc2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "onboarding_request",
+        sa.Column("help_thread_ts", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("onboarding_request", "help_thread_ts")

--- a/backend/alembic/versions/c40f5a073fc2_onboarding_request.py
+++ b/backend/alembic/versions/c40f5a073fc2_onboarding_request.py
@@ -1,0 +1,75 @@
+"""onboarding_request
+
+Revision ID: c40f5a073fc2
+Revises: 31f30b318163
+Create Date: 2026-07-17 00:00:00.000000
+
+Adds the onboarding_request table backing the self-serve team-onboarding flow
+(form -> admin approval -> auto-provision + scrape). All columns additive/new
+table, so no impact on existing data.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "c40f5a073fc2"
+down_revision = "31f30b318163"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "onboarding_request",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "requester_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id"),
+            nullable=True,
+        ),
+        sa.Column("requester_email", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("payload", postgresql.JSONB(), nullable=False),
+        sa.Column(
+            "approver_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id"),
+            nullable=True,
+        ),
+        sa.Column("decision_reason", sa.Text(), nullable=True),
+        sa.Column("error_msg", sa.Text(), nullable=True),
+        sa.Column(
+            "persona_id", sa.Integer(), sa.ForeignKey("persona.id"), nullable=True
+        ),
+        sa.Column(
+            "document_set_id",
+            sa.Integer(),
+            sa.ForeignKey("document_set.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "slack_bot_config_id",
+            sa.Integer(),
+            sa.ForeignKey("slack_bot_config.id"),
+            nullable=True,
+        ),
+        sa.Column("cc_pair_ids", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("onboarding_request")

--- a/backend/danswer/background/update.py
+++ b/backend/danswer/background/update.py
@@ -38,6 +38,7 @@ from danswer.db.models import IndexAttempt
 from danswer.db.models import IndexingStatus
 from danswer.db.models import IndexModelStatus
 from danswer.db.swap_index import check_index_swap
+from danswer.onboarding.provision import finalize_ready_onboarding_requests
 from danswer.search.search_nlp_models import warm_up_encoders
 from danswer.utils.logger import setup_logger
 from danswer.utils.variable_functionality import global_version
@@ -569,6 +570,11 @@ def update_loop(delay: int = 10, num_workers: int = NUM_INDEXING_WORKERS) -> Non
         client_secondary = SimpleJobClient(n_workers=num_workers)
 
     existing_jobs: dict[int, Future | SimpleJob] = {}
+    # Onboarding requests are finalized (doc set + assistant + Slack config) once
+    # all their sources finish scraping. Sweep for ready ones about once a minute
+    # rather than every scheduler tick.
+    last_onboarding_sweep = 0.0
+    onboarding_sweep_interval = 60.0
 
     while True:
         start = time.time()
@@ -594,6 +600,17 @@ def update_loop(delay: int = 10, num_workers: int = NUM_INDEXING_WORKERS) -> Non
             )
         except Exception as e:
             logger.exception(f"Failed to run update due to {e}")
+
+        # Onboarding finalization sweep (~once a minute), isolated so a failure
+        # here never disrupts indexing scheduling.
+        if start - last_onboarding_sweep >= onboarding_sweep_interval:
+            last_onboarding_sweep = start
+            try:
+                with Session(get_sqlalchemy_engine()) as db_session:
+                    finalize_ready_onboarding_requests(db_session)
+            except Exception:
+                logger.exception("Onboarding finalization sweep failed")
+
         sleep_time = delay - (time.time() - start)
         if sleep_time > 0:
             time.sleep(sleep_time)

--- a/backend/danswer/connectors/slack/connector.py
+++ b/backend/danswer/connectors/slack/connector.py
@@ -27,6 +27,7 @@ from danswer.connectors.slack.utils import get_message_link
 from danswer.connectors.slack.utils import make_slack_api_call_logged
 from danswer.connectors.slack.utils import make_slack_api_call_paginated
 from danswer.connectors.slack.utils import make_slack_api_rate_limited
+from danswer.connectors.slack.utils import resolve_workspace_subdomain
 from danswer.connectors.slack.utils import SlackTextCleaner
 from danswer.utils.logger import setup_logger
 
@@ -323,6 +324,11 @@ def get_all_docs(
             client=client, channel=channel, oldest=oldest, latest=latest
         )
 
+        # Resolve the channel's true workspace subdomain (Grid-safe) lazily on
+        # the first message, then reuse it for every thread in the channel — one
+        # chat.getPermalink call per channel rather than per message.
+        channel_workspace: str | None = None
+
         seen_thread_ts: set[str] = set()
         for message_batch in channel_message_batches:
             for message in message_batch:
@@ -344,9 +350,16 @@ def get_all_docs(
                     filtered_thread = [message]
 
                 if filtered_thread:
+                    if channel_workspace is None:
+                        channel_workspace = resolve_workspace_subdomain(
+                            client=client,
+                            channel_id=channel["id"],
+                            message_ts=filtered_thread[0]["ts"],
+                            fallback=workspace,
+                        )
                     channel_docs += 1
                     yield thread_to_doc(
-                        workspace=workspace,
+                        workspace=channel_workspace,
                         channel=channel,
                         thread=filtered_thread,
                         slack_cleaner=slack_cleaner,

--- a/backend/danswer/connectors/slack/utils.py
+++ b/backend/danswer/connectors/slack/utils.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 from functools import wraps
 from typing import Any
 from typing import cast
+from urllib.parse import urlparse
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -17,6 +18,23 @@ logger = setup_logger()
 
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
+
+# Mis-stored Slack workspace subdomains -> their correct URL subdomain.
+# Historically some connectors were configured with the workspace *display name*
+# ("Product") instead of the URL subdomain ("uipath-product"), so their stored
+# permalinks point at the dead host `product.slack.com`. Keys are matched case-
+# and whitespace-insensitively, so this covers both "Product" and "Product ".
+# This is an explicit allow-map on purpose: only listed subdomains are rewritten,
+# so genuinely different workspaces (uipath-customer-ops, uipath-marketing, ...)
+# and links already on a correct host are left untouched. Add an entry here if a
+# new mis-configured workspace surfaces.
+_SLACK_SUBDOMAIN_FIXES = {
+    "product": "uipath-product",
+}
+
+# Captures the subdomain in the `//<sub>.slack.com` portion of a permalink.
+# `[^/]*?` is non-greedy and tolerates a stray space ("Product .slack.com").
+_SLACK_HOST_RE = re.compile(r"(//)([^/]*?)(\.slack\.com)", re.IGNORECASE)
 
 
 def get_message_link(
@@ -32,6 +50,62 @@ def get_message_link(
         f"https://{workspace}.slack.com/archives/{channel_id}/p{message_ts_without_dot}"
         + (f"?thread_ts={thread_ts}" if thread_ts else "")
     )
+
+
+def normalize_slack_link(url: str) -> str:
+    """Rewrite a mis-stored Slack workspace subdomain to the canonical one.
+
+    Existing indexed docs carry links built from a mis-configured workspace
+    ("Product" -> dead `product.slack.com`). Retrieval reads every citation
+    link back through here, so chat / search / Slack-bot citations all resolve
+    to the real workspace without re-indexing or a data migration. Only the
+    subdomains in `_SLACK_SUBDOMAIN_FIXES` are rewritten; a link on the canonical
+    host, or on a genuinely different workspace, is returned unchanged."""
+    if not url or ".slack.com" not in url.lower():
+        return url
+
+    def _fix(match: "re.Match[str]") -> str:
+        subdomain = match.group(2).strip().lower()
+        canonical = _SLACK_SUBDOMAIN_FIXES.get(subdomain)
+        if canonical is not None:
+            return f"{match.group(1)}{canonical}{match.group(3)}"
+        return match.group(0)
+
+    return _SLACK_HOST_RE.sub(_fix, url, count=1)
+
+
+def resolve_workspace_subdomain(
+    client: WebClient, channel_id: str, message_ts: str, fallback: str
+) -> str:
+    """Ask Slack for the authoritative workspace subdomain of a channel.
+
+    `chat.getPermalink` returns the real permalink for a message, with the
+    correct `<sub>.slack.com` host even under Enterprise Grid (where a single
+    bot can see channels that live in different workspaces, each with its own
+    URL). We resolve this ONCE per channel and reuse it, so the connector no
+    longer depends on a hand-typed `workspace` config being right. Falls back to
+    `fallback` (the configured workspace) if the call fails."""
+    try:
+        resp = client.chat_getPermalink(channel=channel_id, message_ts=message_ts)
+        permalink = cast(str, resp.get("permalink") or "")
+        host = urlparse(permalink).netloc.lower()
+        if host.endswith(".slack.com"):
+            subdomain = host[: -len(".slack.com")]
+            if subdomain:
+                return subdomain
+    except SlackApiError as e:
+        logger.warning(
+            "chat.getPermalink failed for channel %s (%s); "
+            "falling back to configured workspace '%s'",
+            channel_id,
+            e.response.get("error"),
+            fallback,
+        )
+    except Exception as e:
+        logger.warning(
+            "could not resolve workspace subdomain for channel %s: %s", channel_id, e
+        )
+    return fallback
 
 
 def make_slack_api_call_logged(

--- a/backend/danswer/connectors/slack/utils.py
+++ b/backend/danswer/connectors/slack/utils.py
@@ -86,7 +86,11 @@ def resolve_workspace_subdomain(
     longer depends on a hand-typed `workspace` config being right. Falls back to
     `fallback` (the configured workspace) if the call fails."""
     try:
-        resp = client.chat_getPermalink(channel=channel_id, message_ts=message_ts)
+        # Same rate-limit + logging wrapping as every other Slack call in the
+        # connector, so a 429 retries (with Retry-After) instead of falling back.
+        resp = make_slack_api_rate_limited(
+            make_slack_api_call_logged(client.chat_getPermalink)
+        )(channel=channel_id, message_ts=message_ts)
         permalink = cast(str, resp.get("permalink") or "")
         host = urlparse(permalink).netloc.lower()
         if host.endswith(".slack.com"):

--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -1,5 +1,6 @@
 import io
 import ipaddress
+import os
 import random
 import re
 import socket
@@ -161,7 +162,13 @@ def get_internal_links(
 
 def start_playwright() -> Tuple[Playwright, BrowserContext]:
     playwright = sync_playwright().start()
-    browser = playwright.chromium.launch(headless=True)
+    # Optionally launch an installed browser (e.g. system Chrome) instead of the
+    # bundled Chromium. Prod leaves this unset and uses the pinned Chromium in
+    # the Linux image; it exists only so local dev can fall back to a working
+    # browser when the pinned build is incompatible with the host OS (the
+    # chromium-1097 build for playwright 1.41.2 SIGSEGVs on recent macOS).
+    browser_channel = os.environ.get("WEB_CONNECTOR_BROWSER_CHANNEL") or None
+    browser = playwright.chromium.launch(headless=True, channel=browser_channel)
 
     context = browser.new_context(user_agent=DEFAULT_USER_AGENT)
 
@@ -314,7 +321,9 @@ def _uipath_product_prefix(path: str) -> str:
     return "/" + "/".join(segs[:cut])
 
 
-def get_uipath_docs_version_base_urls(base_url: str, max_versions: int = 2) -> list[str]:
+def get_uipath_docs_version_base_urls(
+    base_url: str, max_versions: int = 2
+) -> list[str]:
     """Expand a docs.uipath.com product URL to the base URLs of its latest N
     concrete versions.
 

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -1716,3 +1716,71 @@ class ChatReferral(Base):
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+
+class OnboardingStatus(str, PyEnum):
+    """Lifecycle of a team's self-serve Darwin onboarding request."""
+
+    PENDING = "pending"  # submitted, awaiting admin approval
+    REJECTED = "rejected"  # admin declined
+    PROVISIONING = "provisioning"  # approved; creating connectors/persona/config
+    INDEXING = "indexing"  # resources created; sources scraping
+    COMPLETE = "complete"  # all sources indexed successfully
+    FAILED = "failed"  # provisioning or indexing failed
+
+
+class OnboardingRequest(Base):
+    """A self-serve request to onboard a team/channel onto Darwin. Anyone may
+    submit; only an admin may approve. On approval the provisioning orchestrator
+    (onboarding/provision.py) creates the connectors, document set, assistant, and
+    Slack bot config, then records their ids here so the requester can monitor the
+    per-source scrape status."""
+
+    __tablename__ = "onboarding_request"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    # Who submitted (denormalize email so it survives user deletion / is display-ready).
+    requester_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id"), nullable=True
+    )
+    requester_email: Mapped[str] = mapped_column(String, nullable=False)
+    # Stored as the enum VALUE string (e.g. "pending"), NOT via SA Enum() — the
+    # repo's Enum(native_enum=False) stores the NAME (uppercase), which is a known
+    # footgun. Plain String of `.value` keeps it consistent with the migration.
+    status: Mapped[str] = mapped_column(
+        String, nullable=False, default=OnboardingStatus.PENDING.value
+    )
+    # The full validated form (channel, ordered sources, prompt, SME/oncall/jira
+    # options, docs cloud/onprem roots, etc.) — JSONB for flexibility.
+    payload: Mapped[dict] = mapped_column(postgresql.JSONB(), nullable=False)
+    # Admin who approved/rejected + optional reason.
+    approver_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("user.id"), nullable=True
+    )
+    decision_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Free-text error surfaced when status == FAILED.
+    error_msg: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Provisioned resource ids (populated on approval; drive the status monitor).
+    persona_id: Mapped[int | None] = mapped_column(
+        ForeignKey("persona.id"), nullable=True
+    )
+    document_set_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_set.id"), nullable=True
+    )
+    slack_bot_config_id: Mapped[int | None] = mapped_column(
+        ForeignKey("slack_bot_config.id"), nullable=True
+    )
+    # cc_pair ids created for this onboarding (list[int]); the monitor reads their
+    # indexing status. JSONB list rather than a join table — always used together.
+    cc_pair_ids: Mapped[list[int] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -1776,6 +1776,11 @@ class OnboardingRequest(Base):
     cc_pair_ids: Mapped[list[int] | None] = mapped_column(
         postgresql.JSONB(), nullable=True
     )
+    # Slack message ts of the customer-facing root message posted to #help-darwin
+    # on submit. Subsequent lifecycle updates (approved / complete / failed) are
+    # posted as replies in this thread (thread_ts), so the requester tracks their
+    # request in one quiet thread. Null if the root post failed/was skipped.
+    help_thread_ts: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -1723,6 +1723,7 @@ class OnboardingStatus(str, PyEnum):
 
     PENDING = "pending"  # submitted, awaiting admin approval
     REJECTED = "rejected"  # admin declined
+    CANCELLED = "cancelled"  # withdrawn by the requester while still pending
     PROVISIONING = "provisioning"  # approved; creating connectors/persona/config
     INDEXING = "indexing"  # resources created; sources scraping
     COMPLETE = "complete"  # all sources indexed successfully

--- a/backend/danswer/db/onboarding.py
+++ b/backend/danswer/db/onboarding.py
@@ -111,3 +111,13 @@ def set_provisioned_ids(
     if commit:
         db_session.commit()
     return request
+
+
+def set_help_thread_ts(
+    db_session: Session, request: OnboardingRequest, thread_ts: str
+) -> OnboardingRequest:
+    """Persist the Slack ts of the customer-facing root message so later lifecycle
+    updates can be posted as replies in that thread."""
+    request.help_thread_ts = thread_ts
+    db_session.commit()
+    return request

--- a/backend/danswer/db/onboarding.py
+++ b/backend/danswer/db/onboarding.py
@@ -78,6 +78,16 @@ def update_onboarding_status(
     return request
 
 
+def update_onboarding_payload(
+    db_session: Session, request: OnboardingRequest, payload: dict
+) -> OnboardingRequest:
+    """Replace a request's payload (admin edits a pending request before approving).
+    JSONB is only re-persisted on reassignment, so set a fresh dict."""
+    request.payload = dict(payload)
+    db_session.commit()
+    return request
+
+
 def set_provisioned_ids(
     db_session: Session,
     request: OnboardingRequest,

--- a/backend/danswer/db/onboarding.py
+++ b/backend/danswer/db/onboarding.py
@@ -1,0 +1,103 @@
+"""DB helpers for the self-serve Darwin onboarding flow (see OnboardingRequest).
+
+Status is stored as the enum VALUE string; always write/compare with
+OnboardingStatus(...).value to stay consistent with the column + migration."""
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from danswer.db.models import OnboardingRequest
+from danswer.db.models import OnboardingStatus
+
+
+def create_onboarding_request(
+    db_session: Session,
+    requester_id: UUID | None,
+    requester_email: str,
+    payload: dict,
+) -> OnboardingRequest:
+    request = OnboardingRequest(
+        requester_id=requester_id,
+        requester_email=requester_email,
+        payload=payload,
+        status=OnboardingStatus.PENDING.value,
+    )
+    db_session.add(request)
+    db_session.commit()
+    return request
+
+
+def get_onboarding_request(
+    db_session: Session, request_id: int
+) -> OnboardingRequest | None:
+    return db_session.get(OnboardingRequest, request_id)
+
+
+def list_onboarding_requests(
+    db_session: Session, status: OnboardingStatus | None = None
+) -> list[OnboardingRequest]:
+    """All requests (admin view), newest first; optionally filtered by status."""
+    stmt = select(OnboardingRequest).order_by(OnboardingRequest.created_at.desc())
+    if status is not None:
+        stmt = stmt.where(OnboardingRequest.status == status.value)
+    return list(db_session.execute(stmt).scalars().all())
+
+
+def list_onboarding_requests_for_user(
+    db_session: Session, requester_id: UUID
+) -> list[OnboardingRequest]:
+    """A requester's own submissions, newest first."""
+    stmt = (
+        select(OnboardingRequest)
+        .where(OnboardingRequest.requester_id == requester_id)
+        .order_by(OnboardingRequest.created_at.desc())
+    )
+    return list(db_session.execute(stmt).scalars().all())
+
+
+def update_onboarding_status(
+    db_session: Session,
+    request: OnboardingRequest,
+    status: OnboardingStatus,
+    *,
+    approver_id: UUID | None = None,
+    decision_reason: str | None = None,
+    error_msg: str | None = None,
+    commit: bool = True,
+) -> OnboardingRequest:
+    request.status = status.value
+    if approver_id is not None:
+        request.approver_id = approver_id
+    if decision_reason is not None:
+        request.decision_reason = decision_reason
+    # error_msg is cleared on a non-failed transition, set on failure.
+    request.error_msg = error_msg if status == OnboardingStatus.FAILED else None
+    if commit:
+        db_session.commit()
+    return request
+
+
+def set_provisioned_ids(
+    db_session: Session,
+    request: OnboardingRequest,
+    *,
+    persona_id: int | None = None,
+    document_set_id: int | None = None,
+    slack_bot_config_id: int | None = None,
+    cc_pair_ids: list[int] | None = None,
+    commit: bool = True,
+) -> OnboardingRequest:
+    """Record the resources provisioning created, so the status monitor can map
+    the request to its cc_pairs / assistant."""
+    if persona_id is not None:
+        request.persona_id = persona_id
+    if document_set_id is not None:
+        request.document_set_id = document_set_id
+    if slack_bot_config_id is not None:
+        request.slack_bot_config_id = slack_bot_config_id
+    if cc_pair_ids is not None:
+        request.cc_pair_ids = cc_pair_ids
+    if commit:
+        db_session.commit()
+    return request

--- a/backend/danswer/document_index/vespa/index.py
+++ b/backend/danswer/document_index/vespa/index.py
@@ -59,6 +59,7 @@ from danswer.configs.model_configs import SEARCH_DISTANCE_CUTOFF
 from danswer.connectors.cross_connector_utils.miscellaneous_utils import (
     get_experts_stores_representations,
 )
+from danswer.connectors.slack.utils import normalize_slack_link
 from danswer.document_index.document_index_utils import get_uuid_from_chunk
 from danswer.document_index.interfaces import DocumentIndex
 from danswer.document_index.interfaces import DocumentInsertionRecord
@@ -681,8 +682,12 @@ def _vespa_hit_to_inference_chunk(hit: dict[str, Any]) -> InferenceChunk:
     source_links_dict_unprocessed = (
         json.loads(source_links) if isinstance(source_links, str) else source_links
     )
+    # Slack: historical docs were indexed with a mis-configured workspace, so
+    # their permalinks point at a dead host. Rewrite to the canonical workspace
+    # at read time so every citation (chat / search / Slack bot) resolves.
+    is_slack = str(fields.get(SOURCE_TYPE, "")).lower() == "slack"
     source_links_dict = {
-        int(k): v
+        int(k): (normalize_slack_link(v) if is_slack else v)
         for k, v in cast(dict[str, str], source_links_dict_unprocessed).items()
     }
 

--- a/backend/danswer/main.py
+++ b/backend/danswer/main.py
@@ -63,6 +63,10 @@ from danswer.server.documents.credential import router as credential_router
 from danswer.server.documents.document import router as document_router
 from danswer.server.features.document_set.api import router as document_set_router
 from danswer.server.features.folder.api import router as folder_router
+from danswer.server.features.onboarding.api import (
+    admin_router as admin_onboarding_router,
+)
+from danswer.server.features.onboarding.api import basic_router as onboarding_router
 from danswer.server.features.persona.api import admin_router as admin_persona_router
 from danswer.server.features.persona.api import basic_router as persona_router
 from danswer.server.features.prompt.api import basic_router as prompt_router
@@ -280,6 +284,8 @@ def get_application() -> FastAPI:
     )
     include_router_with_global_prefix_prepended(application, persona_router)
     include_router_with_global_prefix_prepended(application, admin_persona_router)
+    include_router_with_global_prefix_prepended(application, onboarding_router)
+    include_router_with_global_prefix_prepended(application, admin_onboarding_router)
     include_router_with_global_prefix_prepended(application, prompt_router)
     include_router_with_global_prefix_prepended(application, tool_router)
     include_router_with_global_prefix_prepended(application, admin_tool_router)

--- a/backend/danswer/onboarding/notify.py
+++ b/backend/danswer/onboarding/notify.py
@@ -32,12 +32,6 @@ ONBOARDING_NOTIFY_CHANNEL = _resolve_channel(
 )
 
 
-def _sources_summary(payload: dict) -> str:
-    sources = payload.get("sources") or []
-    parts = [f"{s.get('type')}: {s.get('label') or s.get('value')}" for s in sources]
-    return ", ".join(parts) if parts else "none"
-
-
 def _post(text: str, request_id: int | None = None) -> None:
     """Post to the ops channel. Best-effort — never raises."""
     if not ONBOARDING_NOTIFY_CHANNEL:
@@ -70,8 +64,7 @@ def notify_onboarding_submitted(request: OnboardingRequest) -> None:
         f":inbox_tray: *New Darwin onboarding request* from "
         f"*{request.requester_email}*\n"
         f"• Team: *{team}*  →  #{channel}\n"
-        f"• Sources: {_sources_summary(request.payload or {})}\n"
-        f"Review & approve: {WEB_DOMAIN}/admin/onboarding",
+        f"Review & approve: {WEB_DOMAIN}/admin/onboarding/{request.id}",
         request.id,
     )
 
@@ -81,7 +74,8 @@ def notify_onboarding_complete(request: OnboardingRequest) -> None:
     team, channel = _team_and_channel(request)
     _post(
         f":white_check_mark: *Darwin is now live in #{channel}* for *{team}* — "
-        f"all sources scraped, the assistant is wired to the new document set.",
+        f"all sources scraped, the assistant is wired to the new document set.\n"
+        f"Status: {WEB_DOMAIN}/admin/onboarding",
         request.id,
     )
 

--- a/backend/danswer/onboarding/notify.py
+++ b/backend/danswer/onboarding/notify.py
@@ -1,0 +1,53 @@
+"""Slack notifications for the onboarding workflow.
+
+Best-effort: a Slack failure must never break the request itself, so every send
+is wrapped and only logged on error."""
+import os
+
+from slack_sdk import WebClient
+
+from danswer.configs.app_configs import WEB_DOMAIN
+from danswer.danswerbot.slack.tokens import fetch_tokens
+from danswer.db.models import OnboardingRequest
+from danswer.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Channel to notify when a new onboarding request is submitted. Accepts a channel
+# name (the bot must be a member) or a channel id; override via env / configmap.
+ONBOARDING_NOTIFY_CHANNEL = os.environ.get("ONBOARDING_NOTIFY_CHANNEL") or "darwin-devs"
+
+
+def _sources_summary(payload: dict) -> str:
+    sources = payload.get("sources") or []
+    parts = [f"{s.get('type')}: {s.get('label') or s.get('value')}" for s in sources]
+    return ", ".join(parts) if parts else "none"
+
+
+def notify_onboarding_submitted(request: OnboardingRequest) -> None:
+    """Post a heads-up to the ops channel that a new request needs review."""
+    if not ONBOARDING_NOTIFY_CHANNEL:
+        return
+    payload = request.payload or {}
+    team = payload.get("team_name") or "?"
+    channel = (payload.get("channel") or {}).get("channel_name") or "?"
+    review_url = f"{WEB_DOMAIN}/admin/onboarding"
+    text = (
+        f":inbox_tray: *New Darwin onboarding request* from "
+        f"*{request.requester_email}*\n"
+        f"• Team: *{team}*  →  #{channel}\n"
+        f"• Sources: {_sources_summary(payload)}\n"
+        f"Review & approve: {review_url}"
+    )
+    try:
+        client = WebClient(token=fetch_tokens().bot_token)
+        client.chat_postMessage(
+            channel=ONBOARDING_NOTIFY_CHANNEL, text=text, unfurl_links=False
+        )
+    except Exception as e:
+        logger.warning(
+            "failed to notify '%s' of onboarding request %s: %s",
+            ONBOARDING_NOTIFY_CHANNEL,
+            request.id,
+            e,
+        )

--- a/backend/danswer/onboarding/notify.py
+++ b/backend/danswer/onboarding/notify.py
@@ -23,12 +23,20 @@ def _resolve_channel(value: str) -> str:
     return m.group(1) if m else (value or "").strip()
 
 
-# Channel to notify when a new onboarding request is submitted, addressed by ID.
-# Default is #darwin-devs (C07B2V8E99S) — a PRIVATE channel in another Grid
-# workspace, so it must be addressed by id, not name. The DanswerBot app token is
-# a member. Override via env/configmap (an id, a name, or a channel link).
+# INTERNAL ops channel — admin review link + real error details. Default
+# #darwin-devs (C07B2V8E99S), a PRIVATE cross-Grid channel addressed by id; the
+# bot is a member. Override via env/configmap (id, name, or channel link).
 ONBOARDING_NOTIFY_CHANNEL = _resolve_channel(
     os.environ.get("ONBOARDING_NOTIFY_CHANNEL") or "C07B2V8E99S"
+)
+
+# CUSTOMER-FACING channel — the requester is @mentioned on submit and every
+# lifecycle update is posted as a *reply in that one thread* (never new top-level
+# messages, so a large channel isn't spammed). Defaults to #darwin-devs for
+# testing; set ONBOARDING_CLIENT_CHANNEL to #help-darwin (C077AFEGCKZ) in prod
+# once the bot has been added there.
+ONBOARDING_CLIENT_CHANNEL = _resolve_channel(
+    os.environ.get("ONBOARDING_CLIENT_CHANNEL") or "C07B2V8E99S"
 )
 
 
@@ -87,4 +95,113 @@ def notify_onboarding_failed(request: OnboardingRequest, detail: str) -> None:
         f":x: *Darwin onboarding failed for {team}* (#{channel}) — {detail}\n"
         f"Details: {WEB_DOMAIN}/admin/onboarding",
         request.id,
+    )
+
+
+# --- customer-facing thread (#help-darwin) ----------------------------------
+
+
+def _mention(client: WebClient, email: str | None) -> str:
+    """Resolve requester email -> Slack @mention; fall back to the email text
+    (e.g. external address not in the workspace). Never raises."""
+    if not email:
+        return "there"
+    try:
+        uid = client.users_lookupByEmail(email=email)["user"]["id"]
+        return f"<@{uid}>"
+    except Exception:
+        return email
+
+
+def _ensure_member(client: WebClient, channel_id: str) -> None:
+    """Best-effort join so the bot can post to a public channel. No-op/ignored
+    for private channels (already invited) or when the scope is missing."""
+    try:
+        client.conversations_join(channel=channel_id)
+    except Exception:
+        pass
+
+
+def notify_client_submitted(request: OnboardingRequest) -> str | None:
+    """Root customer-facing message on submit: @mention the requester + tracking
+    link. Returns the message ts to persist so later updates thread under it.
+    Returns None (and posts nothing further) on any failure — callers must handle
+    a missing ts by skipping replies, never by posting top-level."""
+    if not ONBOARDING_CLIENT_CHANNEL:
+        return None
+    team, channel = _team_and_channel(request)
+    try:
+        client = WebClient(token=fetch_tokens().bot_token)
+        _ensure_member(client, ONBOARDING_CLIENT_CHANNEL)
+        who = _mention(client, request.requester_email)
+        resp = client.chat_postMessage(
+            channel=ONBOARDING_CLIENT_CHANNEL,
+            text=(
+                f":wave: Hi {who} — your *Darwin onboarding request* for *{team}* "
+                f"(#{channel}) has been received. Track its status any time here: "
+                f"{WEB_DOMAIN}/onboarding?view=requests\n"
+                f"I'll post updates in this thread as it progresses."
+            ),
+            unfurl_links=False,
+        )
+        return resp.get("ts")
+    except Exception as e:
+        logger.warning(
+            "failed to post customer onboarding root for request %s: %s",
+            request.id,
+            e,
+        )
+        return None
+
+
+def _client_reply(request: OnboardingRequest, text: str) -> None:
+    """Post a threaded reply under the request's root message. Skips entirely if
+    there is no stored thread ts — a large customer channel must never receive
+    stray top-level messages. Best-effort; never raises."""
+    ts = getattr(request, "help_thread_ts", None)
+    if not ts or not ONBOARDING_CLIENT_CHANNEL:
+        return
+    try:
+        client = WebClient(token=fetch_tokens().bot_token)
+        client.chat_postMessage(
+            channel=ONBOARDING_CLIENT_CHANNEL,
+            text=text,
+            thread_ts=ts,
+            unfurl_links=False,
+        )
+    except Exception as e:
+        logger.warning(
+            "failed to post customer onboarding reply for request %s: %s",
+            request.id,
+            e,
+        )
+
+
+def notify_client_approved(request: OnboardingRequest) -> None:
+    """Reply: admin reviewed + approved; indexing has started."""
+    _client_reply(
+        request,
+        ":white_check_mark: Your request has been reviewed and *approved* — "
+        "Darwin is now indexing your sources. I'll update this thread once it's "
+        "live.",
+    )
+
+
+def notify_client_complete(request: OnboardingRequest) -> None:
+    """Reply: all sources indexed, assistant live in the channel."""
+    _, channel = _team_and_channel(request)
+    _client_reply(
+        request,
+        f":tada: *Darwin is now live in #{channel}!* All your sources are indexed "
+        f"and the assistant is ready — just ask it a question in the channel.",
+    )
+
+
+def notify_client_failed(request: OnboardingRequest) -> None:
+    """Reply: a source failed; team notified. No internal error details here."""
+    _client_reply(
+        request,
+        ":warning: One of your sources hit a snag while indexing. Our team has "
+        "been notified and is looking into it — nothing needed from you; I'll "
+        "update this thread with progress.",
     )

--- a/backend/danswer/onboarding/notify.py
+++ b/backend/danswer/onboarding/notify.py
@@ -3,6 +3,7 @@
 Best-effort: a Slack failure must never break the request itself, so every send
 is wrapped and only logged on error."""
 import os
+import re
 
 from slack_sdk import WebClient
 
@@ -13,9 +14,22 @@ from danswer.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Channel to notify when a new onboarding request is submitted. Accepts a channel
-# name (the bot must be a member) or a channel id; override via env / configmap.
-ONBOARDING_NOTIFY_CHANNEL = os.environ.get("ONBOARDING_NOTIFY_CHANNEL") or "darwin-devs"
+_ARCHIVES_RE = re.compile(r"/archives/(C[A-Z0-9]+)")
+
+
+def _resolve_channel(value: str) -> str:
+    """Accept a channel id, a bare name, or a pasted channel link (id parsed out)."""
+    m = _ARCHIVES_RE.search(value or "")
+    return m.group(1) if m else (value or "").strip()
+
+
+# Channel to notify when a new onboarding request is submitted, addressed by ID.
+# Default is #darwin-devs (C07B2V8E99S) — a PRIVATE channel in another Grid
+# workspace, so it must be addressed by id, not name. The DanswerBot app token is
+# a member. Override via env/configmap (an id, a name, or a channel link).
+ONBOARDING_NOTIFY_CHANNEL = _resolve_channel(
+    os.environ.get("ONBOARDING_NOTIFY_CHANNEL") or "C07B2V8E99S"
+)
 
 
 def _sources_summary(payload: dict) -> str:

--- a/backend/danswer/onboarding/notify.py
+++ b/backend/danswer/onboarding/notify.py
@@ -38,21 +38,10 @@ def _sources_summary(payload: dict) -> str:
     return ", ".join(parts) if parts else "none"
 
 
-def notify_onboarding_submitted(request: OnboardingRequest) -> None:
-    """Post a heads-up to the ops channel that a new request needs review."""
+def _post(text: str, request_id: int | None = None) -> None:
+    """Post to the ops channel. Best-effort — never raises."""
     if not ONBOARDING_NOTIFY_CHANNEL:
         return
-    payload = request.payload or {}
-    team = payload.get("team_name") or "?"
-    channel = (payload.get("channel") or {}).get("channel_name") or "?"
-    review_url = f"{WEB_DOMAIN}/admin/onboarding"
-    text = (
-        f":inbox_tray: *New Darwin onboarding request* from "
-        f"*{request.requester_email}*\n"
-        f"• Team: *{team}*  →  #{channel}\n"
-        f"• Sources: {_sources_summary(payload)}\n"
-        f"Review & approve: {review_url}"
-    )
     try:
         client = WebClient(token=fetch_tokens().bot_token)
         client.chat_postMessage(
@@ -62,6 +51,46 @@ def notify_onboarding_submitted(request: OnboardingRequest) -> None:
         logger.warning(
             "failed to notify '%s' of onboarding request %s: %s",
             ONBOARDING_NOTIFY_CHANNEL,
-            request.id,
+            request_id,
             e,
         )
+
+
+def _team_and_channel(request: OnboardingRequest) -> tuple[str, str]:
+    payload = request.payload or {}
+    team = payload.get("team_name") or "?"
+    channel = (payload.get("channel") or {}).get("channel_name") or "?"
+    return team, channel
+
+
+def notify_onboarding_submitted(request: OnboardingRequest) -> None:
+    """A new request was submitted and needs admin review."""
+    team, channel = _team_and_channel(request)
+    _post(
+        f":inbox_tray: *New Darwin onboarding request* from "
+        f"*{request.requester_email}*\n"
+        f"• Team: *{team}*  →  #{channel}\n"
+        f"• Sources: {_sources_summary(request.payload or {})}\n"
+        f"Review & approve: {WEB_DOMAIN}/admin/onboarding",
+        request.id,
+    )
+
+
+def notify_onboarding_complete(request: OnboardingRequest) -> None:
+    """All sources scraped, assistant wired up, Darwin live in the channel."""
+    team, channel = _team_and_channel(request)
+    _post(
+        f":white_check_mark: *Darwin is now live in #{channel}* for *{team}* — "
+        f"all sources scraped, the assistant is wired to the new document set.",
+        request.id,
+    )
+
+
+def notify_onboarding_failed(request: OnboardingRequest, detail: str) -> None:
+    """One or more sources failed to scrape (or provisioning errored)."""
+    team, channel = _team_and_channel(request)
+    _post(
+        f":x: *Darwin onboarding failed for {team}* (#{channel}) — {detail}\n"
+        f"Details: {WEB_DOMAIN}/admin/onboarding",
+        request.id,
+    )

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -1,15 +1,21 @@
 """Provisioning orchestrator for approved onboarding requests.
 
-On admin approval this turns a validated onboarding payload into real Darwin
-resources, in order:
+Two phases, so Darwin only goes live in a channel once it actually has the
+knowledge:
+
+Phase 1 — `provision_onboarding` (on admin approval):
   per source -> Connector (+ credential) -> connector_credential_pair
-  -> DocumentSet (over all cc_pairs)
-  -> Prompt (Orchestrator's as the default template, overridden by the requester)
-  -> Persona (the team's assistant, scoped to the document set)
-  -> slack_bot_config (channel -> persona, with SME / oncall / Jira options and
-     the requested source order as prioritized_sources)
   -> one high-priority IndexAttempt per cc_pair (so the new sources scrape first)
-and records the created ids on the OnboardingRequest for status monitoring.
+  -> status INDEXING. Redundant child Confluence pages are dropped (parent only);
+  per-source scrape cadence is set (Slack/Confluence/Jira daily, docs monthly).
+
+Phase 2 — `finalize_onboarding` (background sweep, once every source is scraped):
+  DocumentSet (over the cc_pairs) -> Prompt (Orchestrator default, requester-
+  edited) -> Persona (tied to the document set) -> slack_bot_config (channel ->
+  persona, SME / oncall / Jira options, prioritized_sources) -> status COMPLETE,
+  and a #darwin-devs notification. The sweep (`finalize_ready_onboarding_requests`)
+  also flags source failures; it re-checks FAILED requests too, so fixing +
+  re-indexing a source lets it complete with nothing to restart.
 
 Payload contract (assembled + validated by the form):
   {
@@ -29,32 +35,41 @@ import ipaddress
 import socket
 from urllib.parse import urlparse
 
+from sqlalchemy import desc
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from danswer.configs.constants import DocumentSource
+from danswer.connectors.confluence.connector import extract_confluence_keys_from_url
 from danswer.connectors.models import InputType
 from danswer.db.connector import create_connector
 from danswer.db.connector_credential_pair import add_credential_to_connector
+from danswer.db.connector_credential_pair import get_connector_credential_pair_from_id
 from danswer.db.document_set import insert_document_set
 from danswer.db.embedding_model import get_current_db_embedding_model
 from danswer.db.index_attempt import create_index_attempt
 from danswer.db.models import ChannelConfig
 from danswer.db.models import Connector
 from danswer.db.models import Credential
+from danswer.db.models import IndexAttempt
+from danswer.db.models import IndexingStatus
 from danswer.db.models import OnboardingRequest
 from danswer.db.models import OnboardingStatus
 from danswer.db.models import Prompt
 from danswer.db.models import RecencyBiasSetting
 from danswer.db.models import SlackBotResponseType
 from danswer.db.models import User
+from danswer.db.onboarding import list_onboarding_requests
 from danswer.db.onboarding import set_provisioned_ids
 from danswer.db.onboarding import update_onboarding_status
 from danswer.db.persona import get_persona_by_name
 from danswer.db.persona import upsert_persona
 from danswer.db.persona import upsert_prompt
 from danswer.db.slack_bot_config import insert_slack_bot_config
+from danswer.onboarding.notify import notify_onboarding_complete
+from danswer.onboarding.notify import notify_onboarding_failed
 from danswer.onboarding.validation import _allowed_confluence_hosts
+from danswer.onboarding.validation import confluence_page_ancestors
 from danswer.onboarding.validation import jira_base_url
 from danswer.onboarding.validation import validate_confluence_url
 from danswer.onboarding.validation import validate_github_repo
@@ -68,7 +83,17 @@ logger = setup_logger()
 
 # Onboarded sources scrape ahead of routine re-indexing (IndexAttempt priority 0-100).
 ONBOARDING_INDEXING_PRIORITY = 80
-DEFAULT_REFRESH_FREQ = 86400  # daily; picks up new docs versions / channel messages
+DEFAULT_REFRESH_FREQ = 86400  # daily
+_MONTHLY_REFRESH_FREQ = 2592000  # 30 days
+
+# Per-source scrape cadence: Slack / Confluence / Jira change often (daily); docs
+# sites change slowly and are large, so monthly.
+REFRESH_FREQ_BY_SOURCE = {
+    "slack": DEFAULT_REFRESH_FREQ,
+    "confluence": DEFAULT_REFRESH_FREQ,
+    "jira": DEFAULT_REFRESH_FREQ,
+    "web": _MONTHLY_REFRESH_FREQ,  # docs
+}
 PUBLIC_CREDENTIAL_ID = (
     0  # the empty public credential (create_initial_public_credential)
 )
@@ -169,6 +194,7 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
     stype = source["type"]
     value = source["value"]
     label = source.get("label") or value
+    refresh_freq = REFRESH_FREQ_BY_SOURCE.get(stype, DEFAULT_REFRESH_FREQ)
 
     if stype == "web":
         # SSRF guard: never let a submitted URL point the crawler at internal
@@ -185,7 +211,7 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
             source=DocumentSource.WEB,
             input_type=InputType.POLL,
             connector_specific_config=config,
-            refresh_freq=DEFAULT_REFRESH_FREQ,
+            refresh_freq=refresh_freq,
             prune_freq=None,
             disabled=False,
         )
@@ -207,7 +233,7 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
             source=DocumentSource.CONFLUENCE,
             input_type=InputType.POLL,
             connector_specific_config={"wiki_page_url": value},
-            refresh_freq=DEFAULT_REFRESH_FREQ,
+            refresh_freq=refresh_freq,
             prune_freq=None,
             disabled=False,
         )
@@ -226,7 +252,7 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
                 "include_prs": True,
                 "include_issues": True,
             },
-            refresh_freq=DEFAULT_REFRESH_FREQ,
+            refresh_freq=refresh_freq,
             prune_freq=None,
             disabled=False,
         )
@@ -243,7 +269,7 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
                 "channels": [value.lstrip("#")],
                 "channel_regex_enabled": False,
             },
-            refresh_freq=DEFAULT_REFRESH_FREQ,
+            refresh_freq=refresh_freq,
             prune_freq=None,
             disabled=False,
         )
@@ -258,7 +284,7 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
             source=DocumentSource.JIRA,
             input_type=InputType.POLL,
             connector_specific_config={"jira_base_url": base, "jira_filter": value},
-            refresh_freq=DEFAULT_REFRESH_FREQ,
+            refresh_freq=refresh_freq,
             prune_freq=None,
             disabled=False,
         )
@@ -299,7 +325,9 @@ def _source_type_value(source_type: str) -> str:
     }.get(source_type, source_type)
 
 
-def _build_prompt(payload: dict, admin_user: User, db_session: Session) -> Prompt:
+def _build_prompt(
+    payload: dict, admin_user: User | None, db_session: Session
+) -> Prompt:
     """Create the team's prompt, defaulting to the Orchestrator persona's prompt
     and overriding with whatever the requester edited in the form."""
     template = get_persona_by_name(_DEFAULT_TEMPLATE_PERSONA, admin_user, db_session)
@@ -360,13 +388,66 @@ def _build_channel_config(
     return config
 
 
+def _prioritized_sources(sources: list[dict]) -> list[str]:
+    """Distinct DocumentSource values in the requester's priority order."""
+    ordered: list[str] = []
+    for s in sources:
+        st = _source_type_value(s["type"])
+        if st not in ordered:
+            ordered.append(st)
+    return ordered
+
+
+def _dedup_confluence_sources(sources: list[dict], db_session: Session) -> list[dict]:
+    """Drop child Confluence pages when a parent is also provided, keeping the
+    parent alone (the connector already recurses a page's descendants). A whole-
+    space URL supersedes any page in that space; a parent page supersedes its
+    descendant pages (best-effort via the Confluence ancestry API)."""
+    conf = [(i, s) for i, s in enumerate(sources) if s.get("type") == "confluence"]
+    if len(conf) < 2:
+        return sources
+    keys: dict[int, tuple[str, str]] = {}
+    for i, s in conf:
+        try:
+            _b, space, page_id, _c = extract_confluence_keys_from_url(s["value"])
+            keys[i] = (space.lower(), page_id or "")
+        except Exception:
+            keys[i] = ("", "")
+    drop: set[int] = set()
+
+    # A whole-space URL supersedes pages in the same space.
+    space_roots = {sp for (sp, pid) in keys.values() if sp and not pid}
+    for i, _s in conf:
+        sp, pid = keys[i]
+        if pid and sp in space_roots:
+            drop.add(i)
+
+    # A parent page supersedes its descendant pages (best-effort).
+    remaining = [i for i, _s in conf if i not in drop and keys[i][1]]
+    if len(remaining) >= 2:
+        provided = {keys[i][1] for i in remaining}
+        ancestry = confluence_page_ancestors(list(provided), db_session)
+        for i in remaining:
+            if provided & set(ancestry.get(keys[i][1], [])):
+                drop.add(i)  # an ancestor of this page was also provided
+
+    if drop:
+        logger.info(
+            "onboarding: dropped %d redundant child Confluence source(s)", len(drop)
+        )
+    return [s for i, s in enumerate(sources) if i not in drop]
+
+
 def provision_onboarding(
     request: OnboardingRequest,
     admin_user: User,
     db_session: Session,
 ) -> OnboardingRequest:
-    """Create all resources for an approved request. On any failure the request
-    is marked FAILED with the error and the exception is re-raised."""
+    """Phase 1 (on approval): create the connectors + cc_pairs and kick off
+    high-priority indexing; status -> INDEXING. The document set, assistant, and
+    Slack config are created later by `finalize_onboarding`, once every source
+    has finished scraping (so Darwin only goes live once it has real knowledge).
+    On any failure here the request is marked FAILED and the exception re-raised."""
     payload = request.payload
     update_onboarding_status(
         db_session, request, OnboardingStatus.PROVISIONING, approver_id=admin_user.id
@@ -374,12 +455,11 @@ def provision_onboarding(
     try:
         embedding_model = get_current_db_embedding_model(db_session)
         team = payload["team_name"]
+        sources = _dedup_confluence_sources(list(payload["sources"]), db_session)
 
-        # 1) connectors + cc_pairs (track connector/credential ids for indexing).
         cc_pair_ids: list[int] = []
         index_targets: list[tuple[int, int]] = []  # (connector_id, credential_id)
-        prioritized_sources: list[str] = []
-        for source in payload["sources"]:
+        for source in sources:
             # Preflight: the reusable credential must be able to reach the source.
             _assert_source_accessible(source, db_session)
             connector = create_connector(
@@ -399,65 +479,10 @@ def provision_onboarding(
                 raise ValueError(f"Failed to create cc_pair for {source['value']}")
             cc_pair_ids.append(ccp.data)
             index_targets.append((connector_id, credential_id))
-            st = _source_type_value(source["type"])
-            if st not in prioritized_sources:
-                prioritized_sources.append(st)
 
-        # 2) document set over all cc_pairs.
-        doc_set, _ = insert_document_set(
-            DocumentSetCreationRequest(
-                name=f"[onboarding] {team}",
-                description=f"Sources onboarded for {team}",
-                cc_pair_ids=cc_pair_ids,
-                is_public=True,
-            ),
-            admin_user.id,
-            db_session,
-        )
+        set_provisioned_ids(db_session, request, cc_pair_ids=cc_pair_ids)
 
-        # 3) prompt (Orchestrator default + requester edits) + persona.
-        prompt = _build_prompt(payload, admin_user, db_session)
-        persona = upsert_persona(
-            user=admin_user,
-            name=team,
-            description=f"Assistant for {team} (self-serve onboarding)",
-            num_chunks=10,
-            llm_relevance_filter=False,
-            llm_filter_extraction=False,
-            recency_bias=RecencyBiasSetting.BASE_DECAY,
-            llm_model_provider_override=None,
-            llm_model_version_override=None,
-            starter_messages=None,
-            is_public=True,
-            db_session=db_session,
-            prompt_ids=[prompt.id],
-            document_set_ids=[doc_set.id],
-        )
-
-        # 4) slack bot config (channel -> persona) with the options + priority order.
-        channel_config = _build_channel_config(payload, prioritized_sources)
-        response_type = (
-            SlackBotResponseType.QUOTES
-            if payload.get("response_type") == "quotes"
-            else SlackBotResponseType.CITATIONS
-        )
-        slack_config = insert_slack_bot_config(
-            persona_id=persona.id,
-            channel_config=channel_config,
-            response_type=response_type,
-            db_session=db_session,
-        )
-
-        set_provisioned_ids(
-            db_session,
-            request,
-            persona_id=persona.id,
-            document_set_id=doc_set.id,
-            slack_bot_config_id=slack_config.id,
-            cc_pair_ids=cc_pair_ids,
-        )
-
-        # 5) kick off high-priority indexing for each new source.
+        # Kick off high-priority indexing for each source.
         for connector_id, credential_id in index_targets:
             create_index_attempt(
                 connector_id=connector_id,
@@ -470,11 +495,9 @@ def provision_onboarding(
 
         update_onboarding_status(db_session, request, OnboardingStatus.INDEXING)
         logger.info(
-            "onboarding %s provisioned: persona=%s doc_set=%s config=%s cc_pairs=%s",
+            "onboarding %s provisioned %d source(s); indexing. cc_pairs=%s",
             request.id,
-            persona.id,
-            doc_set.id,
-            slack_config.id,
+            len(cc_pair_ids),
             cc_pair_ids,
         )
         return request
@@ -484,3 +507,147 @@ def provision_onboarding(
             db_session, request, OnboardingStatus.FAILED, error_msg=str(e)
         )
         raise
+
+
+def _finalize_owner(request: OnboardingRequest, db_session: Session) -> User | None:
+    """Owner of the created assistant/doc-set — the approver, else the requester.
+    finalize runs in the background, so we resolve it from the row."""
+    for uid in (request.approver_id, request.requester_id):
+        if uid is not None:
+            user = db_session.get(User, uid)
+            if user is not None:
+                return user
+    return None
+
+
+def finalize_onboarding(
+    request: OnboardingRequest, db_session: Session
+) -> OnboardingRequest:
+    """Phase 2 (after all sources are scraped): create the document set over the
+    request's cc_pairs, the assistant (prompt + persona) tied to it, and the Slack
+    bot config — making Darwin live in the channel — then mark COMPLETE + notify."""
+    payload = request.payload
+    owner = _finalize_owner(request, db_session)
+    owner_id = owner.id if owner else None
+    team = payload["team_name"]
+    cc_pair_ids = list(request.cc_pair_ids or [])
+
+    doc_set, _ = insert_document_set(
+        DocumentSetCreationRequest(
+            name=f"[onboarding] {team}",
+            description=f"Sources onboarded for {team}",
+            cc_pair_ids=cc_pair_ids,
+            is_public=True,
+        ),
+        owner_id,
+        db_session,
+    )
+
+    prompt = _build_prompt(payload, owner, db_session)
+    persona = upsert_persona(
+        user=owner,
+        name=team,
+        description=f"Assistant for {team} (self-serve onboarding)",
+        num_chunks=10,
+        llm_relevance_filter=False,
+        llm_filter_extraction=False,
+        recency_bias=RecencyBiasSetting.BASE_DECAY,
+        llm_model_provider_override=None,
+        llm_model_version_override=None,
+        starter_messages=None,
+        is_public=True,
+        db_session=db_session,
+        prompt_ids=[prompt.id],
+        document_set_ids=[doc_set.id],
+    )
+
+    channel_config = _build_channel_config(
+        payload, _prioritized_sources(payload["sources"])
+    )
+    response_type = (
+        SlackBotResponseType.QUOTES
+        if payload.get("response_type") == "quotes"
+        else SlackBotResponseType.CITATIONS
+    )
+    slack_config = insert_slack_bot_config(
+        persona_id=persona.id,
+        channel_config=channel_config,
+        response_type=response_type,
+        db_session=db_session,
+    )
+
+    set_provisioned_ids(
+        db_session,
+        request,
+        persona_id=persona.id,
+        document_set_id=doc_set.id,
+        slack_bot_config_id=slack_config.id,
+    )
+    update_onboarding_status(db_session, request, OnboardingStatus.COMPLETE)
+    logger.info(
+        "onboarding %s finalized: persona=%s doc_set=%s config=%s",
+        request.id,
+        persona.id,
+        doc_set.id,
+        slack_config.id,
+    )
+    notify_onboarding_complete(request)
+    return request
+
+
+def _source_index_state(
+    request: OnboardingRequest, db_session: Session
+) -> tuple[bool, list[str]]:
+    """(all_indexed, failures) from each cc_pair's LATEST index attempt.
+    all_indexed is True only when every source's latest run succeeded; failures
+    lists reasons for any source whose latest run failed."""
+    cc_pair_ids = request.cc_pair_ids or []
+    if not cc_pair_ids:
+        return False, []
+    statuses: list[IndexingStatus | None] = []
+    failures: list[str] = []
+    for cc_id in cc_pair_ids:
+        cc = get_connector_credential_pair_from_id(cc_id, db_session)
+        if cc is None:
+            statuses.append(None)
+            continue
+        latest = db_session.execute(
+            select(IndexAttempt)
+            .where(IndexAttempt.connector_id == cc.connector_id)
+            .where(IndexAttempt.credential_id == cc.credential_id)
+            .order_by(desc(IndexAttempt.time_created))
+            .limit(1)
+        ).scalar_one_or_none()
+        status = latest.status if latest else None
+        statuses.append(status)
+        if status == IndexingStatus.FAILED:
+            reason = (latest.error_msg if latest else None) or "indexing failed"
+            failures.append(f"{cc.name}: {reason[:150]}")
+    all_indexed = bool(statuses) and all(s == IndexingStatus.SUCCESS for s in statuses)
+    return all_indexed, failures
+
+
+def finalize_ready_onboarding_requests(db_session: Session) -> None:
+    """Background poll: for each request still being tracked (INDEXING or FAILED),
+    finalize once all sources have scraped, or flag a failure once. Recoverable by
+    design — a FAILED request whose sources later succeed (after you fix + re-index)
+    is finalized automatically on a later tick; nothing needs restarting."""
+    tracked = list_onboarding_requests(
+        db_session, OnboardingStatus.INDEXING
+    ) + list_onboarding_requests(db_session, OnboardingStatus.FAILED)
+    for request in tracked:
+        try:
+            all_indexed, failures = _source_index_state(request, db_session)
+            if all_indexed:
+                finalize_onboarding(request, db_session)
+            elif failures and request.status == OnboardingStatus.INDEXING.value:
+                # Flip to FAILED + notify ONCE (an already-FAILED request that is
+                # still failing is not re-notified; it stays tracked for recovery).
+                detail = "; ".join(failures)
+                update_onboarding_status(
+                    db_session, request, OnboardingStatus.FAILED, error_msg=detail
+                )
+                notify_onboarding_failed(request, detail)
+        except Exception:
+            logger.exception("onboarding %s finalize check failed", request.id)
+            db_session.rollback()

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -1,0 +1,372 @@
+"""Provisioning orchestrator for approved onboarding requests.
+
+On admin approval this turns a validated onboarding payload into real Darwin
+resources, in order:
+  per source -> Connector (+ credential) -> connector_credential_pair
+  -> DocumentSet (over all cc_pairs)
+  -> Prompt (Orchestrator's as the default template, overridden by the requester)
+  -> Persona (the team's assistant, scoped to the document set)
+  -> slack_bot_config (channel -> persona, with SME / oncall / Jira options and
+     the requested source order as prioritized_sources)
+  -> one high-priority IndexAttempt per cc_pair (so the new sources scrape first)
+and records the created ids on the OnboardingRequest for status monitoring.
+
+Payload contract (assembled + validated by the form):
+  {
+    "team_name": str,
+    "channel": {"channel_id": str, "channel_name": str},
+    "response_type": "citations" | "quotes",
+    "respond_tag_only": bool,
+    "system_prompt": str, "task_prompt": str,           # requester-edited
+    "sme": {"enabled": bool, "group_name": str},
+    "oncall": {"enabled": bool, "schedule": str},       # opsgenie_schedule
+    "jira": {"enabled": bool, "project_key": str, "issue_type": str, "component": str},
+    "sources": [ {"type": "web"|"confluence"|"github"|"slack",
+                  "value": <url|repo-url|channel-name>, "label": str}, ... ]  # priority order
+  }
+"""
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from danswer.configs.constants import DocumentSource
+from danswer.connectors.models import InputType
+from danswer.db.connector import create_connector
+from danswer.db.connector_credential_pair import add_credential_to_connector
+from danswer.db.document_set import insert_document_set
+from danswer.db.embedding_model import get_current_db_embedding_model
+from danswer.db.index_attempt import create_index_attempt
+from danswer.db.models import ChannelConfig
+from danswer.db.models import Connector
+from danswer.db.models import Credential
+from danswer.db.models import OnboardingRequest
+from danswer.db.models import OnboardingStatus
+from danswer.db.models import Prompt
+from danswer.db.models import RecencyBiasSetting
+from danswer.db.models import SlackBotResponseType
+from danswer.db.models import User
+from danswer.db.onboarding import set_provisioned_ids
+from danswer.db.onboarding import update_onboarding_status
+from danswer.db.persona import get_persona_by_name
+from danswer.db.persona import upsert_persona
+from danswer.db.persona import upsert_prompt
+from danswer.db.slack_bot_config import insert_slack_bot_config
+from danswer.server.documents.models import ConnectorBase
+from danswer.server.features.document_set.models import DocumentSetCreationRequest
+from danswer.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Onboarded sources scrape ahead of routine re-indexing (IndexAttempt priority 0-100).
+ONBOARDING_INDEXING_PRIORITY = 80
+DEFAULT_REFRESH_FREQ = 86400  # daily; picks up new docs versions / channel messages
+PUBLIC_CREDENTIAL_ID = (
+    0  # the empty public credential (create_initial_public_credential)
+)
+_DEFAULT_TEMPLATE_PERSONA = "Orchestrator"
+
+
+def _find_credential_id(db_session: Session, required_key: str) -> int | None:
+    """Reuse an existing connector's shared credential for auth'd sources
+    (Confluence/GitHub/Slack) — the requester never supplies tokens."""
+    for cred in db_session.execute(select(Credential)).scalars():
+        if (cred.credential_json or {}).get(required_key):
+            return cred.id
+    return None
+
+
+def _slack_workspace(db_session: Session) -> str | None:
+    for connector in (
+        db_session.execute(
+            select(Connector).where(Connector.source == DocumentSource.SLACK)
+        )
+        .scalars()
+        .all()
+    ):
+        ws = (connector.connector_specific_config or {}).get("workspace")
+        if ws:
+            return ws
+    return None
+
+
+def _parse_github_repo(url: str) -> tuple[str, str]:
+    parts = urlparse(url).path.strip("/").split("/")
+    if len(parts) < 2:
+        raise ValueError(f"Not a github repo URL: {url}")
+    return parts[0], parts[1]
+
+
+def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
+    """One onboarding source -> a ConnectorBase (source-specific config)."""
+    stype = source["type"]
+    value = source["value"]
+    label = source.get("label") or value
+
+    if stype == "web":
+        is_uipath_docs = urlparse(value).netloc == "docs.uipath.com"
+        config: dict = {"base_url": value, "web_connector_type": "recursive"}
+        if is_uipath_docs:
+            # Take the root URL and let the connector crawl all product versions.
+            config["uipath_latest_versions"] = True
+            config["max_versions"] = 2
+        return ConnectorBase(
+            name=f"[onboarding] {label}",
+            source=DocumentSource.WEB,
+            input_type=InputType.POLL,
+            connector_specific_config=config,
+            refresh_freq=DEFAULT_REFRESH_FREQ,
+            prune_freq=None,
+            disabled=False,
+        )
+    if stype == "confluence":
+        return ConnectorBase(
+            name=f"[onboarding] {label}",
+            source=DocumentSource.CONFLUENCE,
+            input_type=InputType.POLL,
+            connector_specific_config={"wiki_page_url": value},
+            refresh_freq=DEFAULT_REFRESH_FREQ,
+            prune_freq=None,
+            disabled=False,
+        )
+    if stype == "github":
+        owner, repo = _parse_github_repo(value)
+        return ConnectorBase(
+            name=f"[onboarding] {label}",
+            source=DocumentSource.GITHUB,
+            input_type=InputType.POLL,
+            connector_specific_config={
+                "repo_owner": owner,
+                "repo_name": repo,
+                "include_prs": True,
+                "include_issues": True,
+            },
+            refresh_freq=DEFAULT_REFRESH_FREQ,
+            prune_freq=None,
+            disabled=False,
+        )
+    if stype == "slack":
+        workspace = _slack_workspace(db_session)
+        if not workspace:
+            raise ValueError("No existing Slack connector to copy the workspace from")
+        return ConnectorBase(
+            name=f"[onboarding] {label}",
+            source=DocumentSource.SLACK,
+            input_type=InputType.POLL,
+            connector_specific_config={
+                "workspace": workspace,
+                "channels": [value.lstrip("#")],
+                "channel_regex_enabled": False,
+            },
+            refresh_freq=DEFAULT_REFRESH_FREQ,
+            prune_freq=None,
+            disabled=False,
+        )
+    raise ValueError(f"Unsupported source type: {stype}")
+
+
+# Which decrypted-credential key identifies a reusable credential per source type.
+_CREDENTIAL_KEY_BY_SOURCE = {
+    "confluence": "confluence_access_token",
+    "github": "github_access_token",
+    "slack": "slack_bot_token",
+}
+
+
+def _credential_id_for_source(source_type: str, db_session: Session) -> int:
+    if source_type == "web":
+        return PUBLIC_CREDENTIAL_ID
+    key = _CREDENTIAL_KEY_BY_SOURCE.get(source_type)
+    if key is None:
+        return PUBLIC_CREDENTIAL_ID
+    cred_id = _find_credential_id(db_session, key)
+    if cred_id is None:
+        raise ValueError(
+            f"No existing {source_type} credential to reuse (missing '{key}')"
+        )
+    return cred_id
+
+
+def _source_type_value(source_type: str) -> str:
+    """Onboarding source type -> DocumentSource value (for prioritized_sources)."""
+    return {
+        "web": DocumentSource.WEB.value,
+        "confluence": DocumentSource.CONFLUENCE.value,
+        "github": DocumentSource.GITHUB.value,
+        "slack": DocumentSource.SLACK.value,
+    }.get(source_type, source_type)
+
+
+def _build_prompt(payload: dict, admin_user: User, db_session: Session) -> Prompt:
+    """Create the team's prompt, defaulting to the Orchestrator persona's prompt
+    and overriding with whatever the requester edited in the form."""
+    template = get_persona_by_name(_DEFAULT_TEMPLATE_PERSONA, admin_user, db_session)
+    default_system = ""
+    default_task = ""
+    if template and template.prompts:
+        default_system = template.prompts[0].system_prompt
+        default_task = template.prompts[0].task_prompt
+    team = payload["team_name"]
+    return upsert_prompt(
+        user=admin_user,
+        name=f"[onboarding] {team} prompt",
+        description=f"Prompt for the {team} assistant (from onboarding)",
+        system_prompt=payload.get("system_prompt") or default_system,
+        task_prompt=payload.get("task_prompt") or default_task,
+        include_citations=True,
+        datetime_aware=True,
+        personas=None,
+        db_session=db_session,
+        default_prompt=False,
+    )
+
+
+def _build_channel_config(
+    payload: dict, prioritized_sources: list[str]
+) -> ChannelConfig:
+    channel_name = payload["channel"]["channel_name"]
+    config: ChannelConfig = {
+        "channel_names": [channel_name],
+        "respond_tag_only": bool(payload.get("respond_tag_only", False)),
+        "prioritized_sources": prioritized_sources,
+    }
+    sme = payload.get("sme") or {}
+    if sme.get("enabled"):
+        config["enable_sme_validation"] = True
+        config["sme_group_name"] = sme.get("group_name", "")
+    oncall = payload.get("oncall") or {}
+    if oncall.get("enabled") and oncall.get("schedule"):
+        config["opsgenie_schedule"] = oncall["schedule"]
+    jira = payload.get("jira") or {}
+    if jira.get("enabled"):
+        config["jira_config"] = {
+            "enable_jira_integration": True,
+            "project_key": jira.get("project_key", ""),
+            "issue_type": jira.get("issue_type", ""),
+            "component": jira.get("component", ""),
+        }
+    return config
+
+
+def provision_onboarding(
+    request: OnboardingRequest,
+    admin_user: User,
+    db_session: Session,
+) -> OnboardingRequest:
+    """Create all resources for an approved request. On any failure the request
+    is marked FAILED with the error and the exception is re-raised."""
+    payload = request.payload
+    update_onboarding_status(
+        db_session, request, OnboardingStatus.PROVISIONING, approver_id=admin_user.id
+    )
+    try:
+        embedding_model = get_current_db_embedding_model(db_session)
+        team = payload["team_name"]
+
+        # 1) connectors + cc_pairs (track connector/credential ids for indexing).
+        cc_pair_ids: list[int] = []
+        index_targets: list[tuple[int, int]] = []  # (connector_id, credential_id)
+        prioritized_sources: list[str] = []
+        for source in payload["sources"]:
+            connector = create_connector(
+                _build_connector_base(source, db_session), db_session
+            )
+            connector_id = int(connector.id)
+            credential_id = _credential_id_for_source(source["type"], db_session)
+            ccp = add_credential_to_connector(
+                connector_id=connector_id,
+                credential_id=credential_id,
+                cc_pair_name=f"[onboarding] {team}: {source.get('label') or source['value']}",
+                is_public=True,
+                user=admin_user,
+                db_session=db_session,
+            )
+            if ccp.data is None:
+                raise ValueError(f"Failed to create cc_pair for {source['value']}")
+            cc_pair_ids.append(ccp.data)
+            index_targets.append((connector_id, credential_id))
+            st = _source_type_value(source["type"])
+            if st not in prioritized_sources:
+                prioritized_sources.append(st)
+
+        # 2) document set over all cc_pairs.
+        doc_set, _ = insert_document_set(
+            DocumentSetCreationRequest(
+                name=f"[onboarding] {team}",
+                description=f"Sources onboarded for {team}",
+                cc_pair_ids=cc_pair_ids,
+                is_public=True,
+            ),
+            admin_user.id,
+            db_session,
+        )
+
+        # 3) prompt (Orchestrator default + requester edits) + persona.
+        prompt = _build_prompt(payload, admin_user, db_session)
+        persona = upsert_persona(
+            user=admin_user,
+            name=team,
+            description=f"Assistant for {team} (self-serve onboarding)",
+            num_chunks=10,
+            llm_relevance_filter=False,
+            llm_filter_extraction=False,
+            recency_bias=RecencyBiasSetting.BASE_DECAY,
+            llm_model_provider_override=None,
+            llm_model_version_override=None,
+            starter_messages=None,
+            is_public=True,
+            db_session=db_session,
+            prompt_ids=[prompt.id],
+            document_set_ids=[doc_set.id],
+        )
+
+        # 4) slack bot config (channel -> persona) with the options + priority order.
+        channel_config = _build_channel_config(payload, prioritized_sources)
+        response_type = (
+            SlackBotResponseType.QUOTES
+            if payload.get("response_type") == "quotes"
+            else SlackBotResponseType.CITATIONS
+        )
+        slack_config = insert_slack_bot_config(
+            persona_id=persona.id,
+            channel_config=channel_config,
+            response_type=response_type,
+            db_session=db_session,
+        )
+
+        set_provisioned_ids(
+            db_session,
+            request,
+            persona_id=persona.id,
+            document_set_id=doc_set.id,
+            slack_bot_config_id=slack_config.id,
+            cc_pair_ids=cc_pair_ids,
+        )
+
+        # 5) kick off high-priority indexing for each new source.
+        for connector_id, credential_id in index_targets:
+            create_index_attempt(
+                connector_id=connector_id,
+                credential_id=credential_id,
+                embedding_model_id=embedding_model.id,
+                db_session=db_session,
+                from_beginning=True,
+                indexing_priority=ONBOARDING_INDEXING_PRIORITY,
+            )
+
+        update_onboarding_status(db_session, request, OnboardingStatus.INDEXING)
+        logger.info(
+            "onboarding %s provisioned: persona=%s doc_set=%s config=%s cc_pairs=%s",
+            request.id,
+            persona.id,
+            doc_set.id,
+            slack_config.id,
+            cc_pair_ids,
+        )
+        return request
+    except Exception as e:
+        logger.exception("onboarding %s provisioning failed", request.id)
+        update_onboarding_status(
+            db_session, request, OnboardingStatus.FAILED, error_msg=str(e)
+        )
+        raise

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -59,6 +59,7 @@ from danswer.db.models import OnboardingStatus
 from danswer.db.models import Prompt
 from danswer.db.models import RecencyBiasSetting
 from danswer.db.models import SlackBotResponseType
+from danswer.db.models import Tool
 from danswer.db.models import User
 from danswer.db.onboarding import list_onboarding_requests
 from danswer.db.onboarding import set_provisioned_ids
@@ -86,6 +87,11 @@ from danswer.utils.logger import setup_logger
 logger = setup_logger()
 
 # Onboarded sources scrape ahead of routine re-indexing (IndexAttempt priority 0-100).
+# in_code_tool_id of the built-in document SearchTool (Tool.in_code_tool_id ==
+# SearchTool.__name__). Kept as a literal to avoid importing the heavy search
+# pipeline into this module.
+_SEARCH_TOOL_IN_CODE_ID = "SearchTool"
+
 ONBOARDING_INDEXING_PRIORITY = 80
 DEFAULT_REFRESH_FREQ = 86400  # daily
 _MONTHLY_REFRESH_FREQ = 2592000  # 30 days
@@ -582,9 +588,24 @@ def finalize_onboarding(
         document_set_id = doc_set.id
         set_provisioned_ids(db_session, request, document_set_id=document_set_id)
 
-    # 2. Assistant (prompt + persona) tied to the document set.
+    # 2. Assistant (prompt + persona) tied to the document set. The SearchTool
+    # MUST be attached or the assistant has the document set but can't actually
+    # search it (upsert_persona only enables search when tool_ids includes it;
+    # the startup auto-add migration doesn't cover personas created later here).
     if persona_id is None:
         prompt = _build_prompt(payload, owner, db_session)
+        search_tool = (
+            db_session.query(Tool)
+            .filter(Tool.in_code_tool_id == _SEARCH_TOOL_IN_CODE_ID)
+            .first()
+        )
+        if search_tool is None:
+            logger.warning(
+                "onboarding %s: SearchTool not found — assistant will have the "
+                "document set but no search tool",
+                request.id,
+            )
+        tool_ids = [search_tool.id] if search_tool else None
         persona = upsert_persona(
             user=owner,
             name=team,
@@ -600,6 +621,7 @@ def finalize_onboarding(
             db_session=db_session,
             prompt_ids=[prompt.id],
             document_set_ids=[document_set_id],
+            tool_ids=tool_ids,
         )
         persona_id = persona.id
         set_provisioned_ids(db_session, request, persona_id=persona_id)

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -55,8 +55,10 @@ from danswer.db.persona import upsert_persona
 from danswer.db.persona import upsert_prompt
 from danswer.db.slack_bot_config import insert_slack_bot_config
 from danswer.onboarding.validation import _allowed_confluence_hosts
+from danswer.onboarding.validation import jira_base_url
 from danswer.onboarding.validation import validate_confluence_url
 from danswer.onboarding.validation import validate_github_repo
+from danswer.onboarding.validation import validate_jira_filter
 from danswer.onboarding.validation import validate_slack_channel
 from danswer.server.documents.models import ConnectorBase
 from danswer.server.features.document_set.models import DocumentSetCreationRequest
@@ -154,6 +156,8 @@ def _assert_source_accessible(source: dict, db_session: Session) -> None:
         result = validate_github_repo(value, db_session)
     elif stype == "slack":
         result = validate_slack_channel(value)
+    elif stype == "jira":
+        result = validate_jira_filter(value, db_session)
     else:
         return
     if not result.valid:
@@ -243,6 +247,21 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
             prune_freq=None,
             disabled=False,
         )
+    if stype == "jira":
+        # value is a JQL filter; reuse an existing Jira connector's base URL so
+        # the requester never supplies the host/credentials.
+        base = jira_base_url(db_session)
+        if not base:
+            raise ValueError("No existing Jira connector to copy the base URL from")
+        return ConnectorBase(
+            name=f"[onboarding] {label}",
+            source=DocumentSource.JIRA,
+            input_type=InputType.POLL,
+            connector_specific_config={"jira_base_url": base, "jira_filter": value},
+            refresh_freq=DEFAULT_REFRESH_FREQ,
+            prune_freq=None,
+            disabled=False,
+        )
     raise ValueError(f"Unsupported source type: {stype}")
 
 
@@ -251,6 +270,7 @@ _CREDENTIAL_KEY_BY_SOURCE = {
     "confluence": "confluence_access_token",
     "github": "github_access_token",
     "slack": "slack_bot_token",
+    "jira": "jira_api_token",
 }
 
 
@@ -275,6 +295,7 @@ def _source_type_value(source_type: str) -> str:
         "confluence": DocumentSource.CONFLUENCE.value,
         "github": DocumentSource.GITHUB.value,
         "slack": DocumentSource.SLACK.value,
+        "jira": DocumentSource.JIRA.value,
     }.get(source_type, source_type)
 
 

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -25,6 +25,8 @@ Payload contract (assembled + validated by the form):
                   "value": <url|repo-url|channel-name>, "label": str}, ... ]  # priority order
   }
 """
+import ipaddress
+import socket
 from urllib.parse import urlparse
 
 from sqlalchemy import select
@@ -52,6 +54,10 @@ from danswer.db.persona import get_persona_by_name
 from danswer.db.persona import upsert_persona
 from danswer.db.persona import upsert_prompt
 from danswer.db.slack_bot_config import insert_slack_bot_config
+from danswer.onboarding.validation import _allowed_confluence_hosts
+from danswer.onboarding.validation import validate_confluence_url
+from danswer.onboarding.validation import validate_github_repo
+from danswer.onboarding.validation import validate_slack_channel
 from danswer.server.documents.models import ConnectorBase
 from danswer.server.features.document_set.models import DocumentSetCreationRequest
 from danswer.utils.logger import setup_logger
@@ -97,6 +103,63 @@ def _parse_github_repo(url: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
+# Hosts we accept for GitHub sources. The connector authenticates against the
+# GitHub API (not the URL host), but pinning the host keeps non-GitHub URLs out.
+_ALLOWED_GITHUB_HOSTS = {"github.com", "www.github.com"}
+
+
+def _assert_public_web_host(url: str) -> None:
+    """SSRF guard for web sources: require an http(s) URL whose host does not
+    resolve to a private / loopback / link-local / reserved address, so an
+    onboarding request can't point the crawler at internal infrastructure.
+
+    Fails closed: a URL we can't parse or resolve is rejected rather than
+    fetched. This is a provision-time check; it doesn't defend against DNS
+    rebinding at fetch time, but it closes the obvious internal-target vector."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Web source URL must be http(s): {url}")
+    host = parsed.hostname
+    if not host:
+        raise ValueError(f"Web source URL has no host: {url}")
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except OSError as e:
+        raise ValueError(f"Could not resolve web source host '{host}': {e}")
+    for info in addr_infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise ValueError(
+                f"Web source host '{host}' resolves to a non-public address ({ip})"
+            )
+
+
+def _assert_source_accessible(source: dict, db_session: Session) -> None:
+    """Fail-fast at provision: confirm the reusable credential can actually reach
+    the source, so we never create a connector that would silently index nothing.
+    Reuses the same validators as the submit-time /validate endpoint. Web sources
+    are public (no credential) and are host-guarded in `_build_connector_base`."""
+    stype = source["type"]
+    value = source["value"]
+    if stype == "confluence":
+        result = validate_confluence_url(value, db_session)
+    elif stype == "github":
+        result = validate_github_repo(value, db_session)
+    elif stype == "slack":
+        result = validate_slack_channel(value)
+    else:
+        return
+    if not result.valid:
+        raise ValueError(f"{stype} source not accessible: {result.message}")
+
+
 def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
     """One onboarding source -> a ConnectorBase (source-specific config)."""
     stype = source["type"]
@@ -104,6 +167,9 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
     label = source.get("label") or value
 
     if stype == "web":
+        # SSRF guard: never let a submitted URL point the crawler at internal
+        # hosts (validation at submit time can be bypassed by a direct API call).
+        _assert_public_web_host(value)
         is_uipath_docs = urlparse(value).netloc == "docs.uipath.com"
         config: dict = {"base_url": value, "web_connector_type": "recursive"}
         if is_uipath_docs:
@@ -120,6 +186,18 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
             disabled=False,
         )
     if stype == "confluence":
+        # Credential-leak / SSRF guard: provisioning creates a connector that
+        # will authenticate to this host with our stored Confluence token, so
+        # only allow a host an existing Confluence connector already uses. Re-run
+        # here (not just at submit) because provisioning is the point the
+        # credential is actually used, and submit-time validation can be skipped.
+        host = urlparse(value).netloc.lower()
+        allowed_hosts = _allowed_confluence_hosts(db_session)
+        if not allowed_hosts or host not in allowed_hosts:
+            raise ValueError(
+                f"Confluence host '{host}' is not allowed — it must match an "
+                f"existing Confluence connector ({sorted(allowed_hosts)})"
+            )
         return ConnectorBase(
             name=f"[onboarding] {label}",
             source=DocumentSource.CONFLUENCE,
@@ -130,6 +208,9 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
             disabled=False,
         )
     if stype == "github":
+        gh_host = (urlparse(value).hostname or "").lower()
+        if gh_host not in _ALLOWED_GITHUB_HOSTS:
+            raise ValueError(f"GitHub source URL must be on github.com: {value}")
         owner, repo = _parse_github_repo(value)
         return ConnectorBase(
             name=f"[onboarding] {label}",
@@ -268,6 +349,8 @@ def provision_onboarding(
         index_targets: list[tuple[int, int]] = []  # (connector_id, credential_id)
         prioritized_sources: list[str] = []
         for source in payload["sources"]:
+            # Preflight: the reusable credential must be able to reach the source.
+            _assert_source_accessible(source, db_session)
             connector = create_connector(
                 _build_connector_base(source, db_session), db_session
             )

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -44,6 +44,7 @@ from danswer.connectors.confluence.connector import extract_confluence_keys_from
 from danswer.connectors.models import InputType
 from danswer.db.connector import create_connector
 from danswer.db.connector_credential_pair import add_credential_to_connector
+from danswer.db.connector_credential_pair import get_connector_credential_pair
 from danswer.db.connector_credential_pair import get_connector_credential_pair_from_id
 from danswer.db.document_set import insert_document_set
 from danswer.db.embedding_model import get_current_db_embedding_model
@@ -478,7 +479,17 @@ def provision_onboarding(
             )
             if ccp.data is None:
                 raise ValueError(f"Failed to create cc_pair for {source['value']}")
-            cc_pair_ids.append(ccp.data)
+            # NB: in this fork add_credential_to_connector returns
+            # data=connector_id, NOT the cc_pair id. Look the pair up by
+            # (connector, credential) to record its real id — otherwise the
+            # request tracks connector ids as if they were cc_pair ids, which
+            # (off by one) points the finalizer/status at the wrong cc_pairs.
+            cc_pair = get_connector_credential_pair(
+                connector_id, credential_id, db_session
+            )
+            if cc_pair is None:
+                raise ValueError(f"Failed to create cc_pair for {source['value']}")
+            cc_pair_ids.append(cc_pair.id)
             index_targets.append((connector_id, credential_id))
 
         set_provisioned_ids(db_session, request, cc_pair_ids=cc_pair_ids)
@@ -532,79 +543,113 @@ def finalize_onboarding(
     owner_id = owner.id if owner else None
     team = payload["team_name"]
     cc_pair_ids = list(request.cc_pair_ids or [])
+    # Capture already-provisioned artifact ids into locals BEFORE dropping the
+    # transaction: the idempotency guards below must not re-open one (a read
+    # would auto-begin) right before insert_document_set's begin().
+    document_set_id = request.document_set_id
+    persona_id = request.persona_id
+    slack_bot_config_id = request.slack_bot_config_id
 
-    doc_set, _ = insert_document_set(
-        DocumentSetCreationRequest(
-            name=f"[onboarding] {team}",
-            description=f"Sources onboarded for {team}",
-            cc_pair_ids=cc_pair_ids,
+    # The finalizer already opened a transaction on this session doing its reads
+    # (list / _source_index_state / _finalize_owner above). insert_document_set
+    # calls db_session.begin(), which raises "A transaction is already begun"
+    # when one is active — so drop the read-only transaction here.
+    db_session.rollback()
+
+    # Idempotent + incremental so this survives a pod crash mid-finalize: create
+    # each artifact only if the request doesn't already reference one, and
+    # persist its id immediately (a checkpoint). A crash between steps resumes on
+    # the next finalizer tick instead of duplicating doc sets / personas / Slack
+    # configs. Each helper commits, so every persisted id is durable.
+
+    # 1. Document set over the request's cc_pairs.
+    if document_set_id is None:
+        doc_set, _ = insert_document_set(
+            DocumentSetCreationRequest(
+                name=f"[onboarding] {team}",
+                description=f"Sources onboarded for {team}",
+                cc_pair_ids=cc_pair_ids,
+                is_public=True,
+            ),
+            owner_id,
+            db_session,
+        )
+        document_set_id = doc_set.id
+        set_provisioned_ids(db_session, request, document_set_id=document_set_id)
+
+    # 2. Assistant (prompt + persona) tied to the document set.
+    if persona_id is None:
+        prompt = _build_prompt(payload, owner, db_session)
+        persona = upsert_persona(
+            user=owner,
+            name=team,
+            description=f"Assistant for {team} (self-serve onboarding)",
+            num_chunks=10,
+            llm_relevance_filter=False,
+            llm_filter_extraction=False,
+            recency_bias=RecencyBiasSetting.BASE_DECAY,
+            llm_model_provider_override=None,
+            llm_model_version_override=None,
+            starter_messages=None,
             is_public=True,
-        ),
-        owner_id,
-        db_session,
-    )
+            db_session=db_session,
+            prompt_ids=[prompt.id],
+            document_set_ids=[document_set_id],
+        )
+        persona_id = persona.id
+        set_provisioned_ids(db_session, request, persona_id=persona_id)
 
-    prompt = _build_prompt(payload, owner, db_session)
-    persona = upsert_persona(
-        user=owner,
-        name=team,
-        description=f"Assistant for {team} (self-serve onboarding)",
-        num_chunks=10,
-        llm_relevance_filter=False,
-        llm_filter_extraction=False,
-        recency_bias=RecencyBiasSetting.BASE_DECAY,
-        llm_model_provider_override=None,
-        llm_model_version_override=None,
-        starter_messages=None,
-        is_public=True,
-        db_session=db_session,
-        prompt_ids=[prompt.id],
-        document_set_ids=[doc_set.id],
-    )
+    # 3. Slack bot config -> persona, making Darwin live in the channel.
+    if slack_bot_config_id is None:
+        channel_config = _build_channel_config(
+            payload, _prioritized_sources(payload["sources"])
+        )
+        response_type = (
+            SlackBotResponseType.QUOTES
+            if payload.get("response_type") == "quotes"
+            else SlackBotResponseType.CITATIONS
+        )
+        slack_config = insert_slack_bot_config(
+            persona_id=persona_id,
+            channel_config=channel_config,
+            response_type=response_type,
+            db_session=db_session,
+        )
+        slack_bot_config_id = slack_config.id
+        set_provisioned_ids(
+            db_session, request, slack_bot_config_id=slack_bot_config_id
+        )
 
-    channel_config = _build_channel_config(
-        payload, _prioritized_sources(payload["sources"])
-    )
-    response_type = (
-        SlackBotResponseType.QUOTES
-        if payload.get("response_type") == "quotes"
-        else SlackBotResponseType.CITATIONS
-    )
-    slack_config = insert_slack_bot_config(
-        persona_id=persona.id,
-        channel_config=channel_config,
-        response_type=response_type,
-        db_session=db_session,
-    )
-
-    set_provisioned_ids(
-        db_session,
-        request,
-        persona_id=persona.id,
-        document_set_id=doc_set.id,
-        slack_bot_config_id=slack_config.id,
-    )
+    # 4. Mark live + notify. A notification failure must not fail finalize — the
+    # request is already COMPLETE (and would otherwise be retried forever).
     update_onboarding_status(db_session, request, OnboardingStatus.COMPLETE)
     logger.info(
         "onboarding %s finalized: persona=%s doc_set=%s config=%s",
         request.id,
-        persona.id,
-        doc_set.id,
-        slack_config.id,
+        persona_id,
+        document_set_id,
+        slack_bot_config_id,
     )
-    notify_onboarding_complete(request)
+    try:
+        notify_onboarding_complete(request)
+    except Exception:
+        logger.exception(
+            "onboarding %s finalized but completion notification failed", request.id
+        )
     return request
 
 
 def _source_index_state(
     request: OnboardingRequest, db_session: Session
-) -> tuple[bool, list[str]]:
-    """(all_indexed, failures) from each cc_pair's LATEST index attempt.
-    all_indexed is True only when every source's latest run succeeded; failures
-    lists reasons for any source whose latest run failed."""
+) -> tuple[bool, list[str], bool]:
+    """(all_indexed, failures, in_progress) from each cc_pair's LATEST index
+    attempt. all_indexed is True only when every source's latest run succeeded;
+    failures lists reasons for any source whose latest run failed; in_progress is
+    True when any source is still scraping (NOT_STARTED / IN_PROGRESS) — used to
+    move a previously-FAILED request back to INDEXING once it's re-indexing."""
     cc_pair_ids = request.cc_pair_ids or []
     if not cc_pair_ids:
-        return False, []
+        return False, [], False
     statuses: list[IndexingStatus | None] = []
     failures: list[str] = []
     for cc_id in cc_pair_ids:
@@ -625,25 +670,50 @@ def _source_index_state(
             reason = (latest.error_msg if latest else None) or "indexing failed"
             failures.append(f"{cc.name}: {reason[:150]}")
     all_indexed = bool(statuses) and all(s == IndexingStatus.SUCCESS for s in statuses)
-    return all_indexed, failures
+    in_progress = any(
+        s in (IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS) for s in statuses
+    )
+    return all_indexed, failures, in_progress
 
 
 def finalize_ready_onboarding_requests(db_session: Session) -> None:
     """Background poll: for each request still being tracked (INDEXING or FAILED),
-    finalize once all sources have scraped, or flag a failure once. Recoverable by
-    design — a FAILED request whose sources later succeed (after you fix + re-index)
-    is finalized automatically on a later tick; nothing needs restarting."""
+    drive its status from the aggregate state of its sources. Ordering matters —
+    in-progress WINS over a failure so the requester never sees a scary FAILED
+    while work is still happening:
+
+      * all sources succeeded            -> finalize (assistant goes live) -> COMPLETE
+      * any source still scraping        -> INDEXING (defer any failure verdict;
+                                            a stale FAILED is cleared back to
+                                            INDEXING so re-indexing shows progress)
+      * settled with >=1 failed source   -> FAILED + notify ONCE
+
+    Recoverable by design: fix + re-index a source and the request climbs back to
+    INDEXING and then COMPLETE on later ticks; nothing needs restarting. An
+    already-FAILED request that is still fully settled+failing is not re-notified."""
     tracked = list_onboarding_requests(
         db_session, OnboardingStatus.INDEXING
     ) + list_onboarding_requests(db_session, OnboardingStatus.FAILED)
     for request in tracked:
         try:
-            all_indexed, failures = _source_index_state(request, db_session)
+            all_indexed, failures, in_progress = _source_index_state(
+                request, db_session
+            )
             if all_indexed:
                 finalize_onboarding(request, db_session)
-            elif failures and request.status == OnboardingStatus.INDEXING.value:
-                # Flip to FAILED + notify ONCE (an already-FAILED request that is
-                # still failing is not re-notified; it stays tracked for recovery).
+            elif in_progress:
+                # Something is still scraping (initial run or a re-index). Show
+                # INDEXING and hold off on any failure verdict — a transient
+                # failure may still be superseded by an in-flight or retried
+                # source. Only flips the row if it isn't already INDEXING (also
+                # clears a stale error_msg from a prior FAILED).
+                if request.status != OnboardingStatus.INDEXING.value:
+                    update_onboarding_status(
+                        db_session, request, OnboardingStatus.INDEXING
+                    )
+            elif failures and request.status != OnboardingStatus.FAILED.value:
+                # Everything settled and at least one source failed: flag FAILED +
+                # notify ONCE (an already-FAILED request is not re-notified).
                 detail = "; ".join(failures)
                 update_onboarding_status(
                     db_session, request, OnboardingStatus.FAILED, error_msg=detail

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -67,6 +67,9 @@ from danswer.db.persona import get_persona_by_name
 from danswer.db.persona import upsert_persona
 from danswer.db.persona import upsert_prompt
 from danswer.db.slack_bot_config import insert_slack_bot_config
+from danswer.onboarding.notify import notify_client_approved
+from danswer.onboarding.notify import notify_client_complete
+from danswer.onboarding.notify import notify_client_failed
 from danswer.onboarding.notify import notify_onboarding_complete
 from danswer.onboarding.notify import notify_onboarding_failed
 from danswer.onboarding.validation import _allowed_confluence_hosts
@@ -512,6 +515,8 @@ def provision_onboarding(
             len(cc_pair_ids),
             cc_pair_ids,
         )
+        # Customer thread: reviewed + approved, indexing started.
+        notify_client_approved(request)
         return request
     except Exception as e:
         logger.exception("onboarding %s provisioning failed", request.id)
@@ -632,6 +637,7 @@ def finalize_onboarding(
     )
     try:
         notify_onboarding_complete(request)
+        notify_client_complete(request)
     except Exception:
         logger.exception(
             "onboarding %s finalized but completion notification failed", request.id
@@ -719,6 +725,7 @@ def finalize_ready_onboarding_requests(db_session: Session) -> None:
                     db_session, request, OnboardingStatus.FAILED, error_msg=detail
                 )
                 notify_onboarding_failed(request, detail)
+                notify_client_failed(request)
         except Exception:
             logger.exception("onboarding %s finalize check failed", request.id)
             db_session.rollback()

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -203,9 +203,10 @@ def _build_connector_base(source: dict, db_session: Session) -> ConnectorBase:
         is_uipath_docs = urlparse(value).netloc == "docs.uipath.com"
         config: dict = {"base_url": value, "web_connector_type": "recursive"}
         if is_uipath_docs:
-            # Take the root URL and let the connector crawl all product versions.
+            # Strip the version from the root URL and crawl the latest few
+            # concrete versions (no need to list each version URL).
             config["uipath_latest_versions"] = True
-            config["max_versions"] = 2
+            config["max_versions"] = 3
         return ConnectorBase(
             name=f"[onboarding] {label}",
             source=DocumentSource.WEB,

--- a/backend/danswer/onboarding/provision.py
+++ b/backend/danswer/onboarding/provision.py
@@ -337,8 +337,18 @@ def _build_channel_config(
         config["enable_sme_validation"] = True
         config["sme_group_name"] = sme.get("group_name", "")
     oncall = payload.get("oncall") or {}
-    if oncall.get("enabled") and oncall.get("schedule"):
-        config["opsgenie_schedule"] = oncall["schedule"]
+    if oncall.get("enabled"):
+        if oncall.get("schedule"):
+            config["opsgenie_schedule"] = oncall["schedule"]
+        # DRI Slack handles/emails to tag on "need more help" (follow_up_tags is
+        # resolved as emails->users then handles/names->user-groups at runtime).
+        handles = [
+            h.strip().lstrip("@")
+            for h in (oncall.get("handles") or "").split(",")
+            if h.strip()
+        ]
+        if handles:
+            config["follow_up_tags"] = handles
     jira = payload.get("jira") or {}
     if jira.get("enabled"):
         config["jira_config"] = {

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -26,9 +26,11 @@ from danswer.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Bounded scan for name->channel lookup (Slack has no name lookup API). Prefer a
-# #mention (carries the id) — that path is a single, exact call.
-_MAX_CHANNEL_PAGES = 12
+# Slack has no name->channel lookup API. On a large Enterprise Grid org a bare
+# name can be thousands of channels deep, so instead of enumerating everything we
+# search only the channels the bot is a MEMBER of (users.conversations — a small
+# set), which is also the real precondition for the bot to operate in a channel.
+_MEMBER_CHANNEL_PAGES = 6  # ~6k channels the bot is in — plenty
 _MENTION_RE = re.compile(r"<#(C[A-Z0-9]+)(?:\|[^>]*)?>")
 _CHANNEL_ID_RE = re.compile(r"^C[A-Z0-9]{6,}$")
 
@@ -42,6 +44,24 @@ class ValidationResult(BaseModel):
 
 def _bot_client() -> WebClient:
     return WebClient(token=fetch_tokens().bot_token)
+
+
+def _find_channel_by_name(
+    method: object, name: str, max_pages: int, **kwargs: object
+) -> dict | None:
+    """Paginate a Slack list endpoint (conversations_list / users_conversations)
+    looking for an exact channel-name match."""
+    cursor: str | None = None
+    for _ in range(max_pages):
+        resp = method(limit=1000, cursor=cursor, **kwargs)  # type: ignore[operator]
+        for ch in resp.get("channels", []):
+            if ch.get("name", "").lower() == name:
+                return ch
+        meta = resp.get("response_metadata")
+        cursor = meta.get("next_cursor") if isinstance(meta, dict) else None
+        if not cursor:
+            break
+    return None
 
 
 def validate_slack_channel(value: str) -> ValidationResult:
@@ -75,34 +95,33 @@ def validate_slack_channel(value: str) -> ValidationResult:
                 message=f"Channel not found or bot lacks access ({e.response.get('error')})",
             )
 
+    # Bare name. Slack has no name->channel lookup API, and every channel-read
+    # endpoint (conversations_info/history/replies) needs the ID, so there's no
+    # cheap indirect check. Rather than enumerate the whole org (tens of
+    # thousands of channels on Enterprise Grid), we search only the channels the
+    # BOT is a member of (users.conversations — a small set) — which is also the
+    # real precondition: the bot must be in the channel to answer and index it.
     name = raw.lstrip("#").lower()
-    cursor: str | None = None
     try:
-        for _ in range(_MAX_CHANNEL_PAGES):
-            resp = client.conversations_list(
-                types="public_channel,private_channel",
-                limit=1000,
-                cursor=cursor,
-                exclude_archived=True,
-            )
-            for ch in resp.get("channels", []):
-                if ch.get("name", "").lower() == name:
-                    return ValidationResult(
-                        valid=True,
-                        message=f"#{ch['name']}",
-                        resolved={"channel_id": ch["id"], "channel_name": ch["name"]},
-                    )
-            meta = resp.get("response_metadata")
-            cursor = meta.get("next_cursor") if isinstance(meta, dict) else None
-            if not cursor:
-                break
+        ch = _find_channel_by_name(
+            client.users_conversations,
+            name,
+            _MEMBER_CHANNEL_PAGES,
+            types="public_channel,private_channel",
+        )
     except SlackApiError as e:
         return ValidationResult(
             valid=False, message=f"Couldn't verify channel ({e.response.get('error')})"
         )
+    if ch:
+        return ValidationResult(
+            valid=True,
+            message=f"#{ch['name']}",
+            resolved={"channel_id": ch["id"], "channel_name": ch["name"]},
+        )
     return ValidationResult(
         valid=False,
-        message="Channel not found — paste it as a #mention to be sure",
+        message=f"The Darwin bot isn't in #{name} yet — invite it to the channel, then re-check.",
     )
 
 

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -14,6 +14,7 @@ from slack_sdk.errors import SlackApiError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from danswer.configs.app_configs import GITHUB_CONNECTOR_BASE_URL
 from danswer.configs.constants import DocumentSource
 from danswer.connectors.confluence.connector import extract_confluence_keys_from_url
 from danswer.connectors.web.connector import _uipath_product_prefix
@@ -200,6 +201,75 @@ def validate_confluence_url(url: str, db_session: Session) -> ValidationResult:
         valid=True,
         message=f"Space '{space}'",
         resolved={"wiki_base": wiki_base, "space": space, "is_cloud": is_cloud},
+    )
+
+
+_GITHUB_HOSTS = {"github.com", "www.github.com"}
+
+
+def _first_github_token(db_session: Session) -> str | None:
+    """Reuse an existing GitHub connector's token for the access check (the
+    requester never supplies one)."""
+    for cred in db_session.execute(select(Credential)).scalars():
+        tok = (cred.credential_json or {}).get("github_access_token")
+        if tok:
+            return tok
+    return None
+
+
+def validate_github_repo(url: str, db_session: Session) -> ValidationResult:
+    """Confirm a github.com repo URL is reachable with the stored GitHub token —
+    i.e. the credential that provisioning will reuse can actually scrape it.
+
+    The token is only ever sent to the GitHub API (github.com or the configured
+    enterprise base URL), never to the URL's host. Errors are reported generically
+    and logged by exception type only, so a token or raw API payload can't leak
+    into a message or the logs."""
+    raw = (url or "").strip()
+    if not raw:
+        return ValidationResult(valid=False, message="Enter a GitHub repo URL")
+    parsed = urlparse(raw)
+    host = (parsed.hostname or "").lower()
+    if host not in _GITHUB_HOSTS:
+        return ValidationResult(valid=False, message="Must be a github.com repo URL")
+    parts = [p for p in parsed.path.strip("/").split("/") if p]
+    if len(parts) < 2:
+        return ValidationResult(
+            valid=False, message="URL must be github.com/<owner>/<repo>"
+        )
+    owner, repo = parts[0], parts[1].removesuffix(".git")
+    full_name = f"{owner}/{repo}"
+
+    token = _first_github_token(db_session)
+    if token is None:
+        return ValidationResult(
+            valid=True,
+            message=f"{full_name} (access unverified — no GitHub credential on file)",
+            resolved={"repo_owner": owner, "repo_name": repo},
+        )
+    try:
+        from github import Github  # type: ignore[import-untyped]
+
+        client = (
+            Github(token, base_url=GITHUB_CONNECTOR_BASE_URL)
+            if GITHUB_CONNECTOR_BASE_URL
+            else Github(token)
+        )
+        client.get_repo(full_name)  # raises if the token can't see the repo
+    except Exception as e:
+        # Log the exception TYPE only — never str(e), which can echo the token
+        # or API payload.
+        logger.info(
+            "github repo access check failed for %s: %s", full_name, type(e).__name__
+        )
+        return ValidationResult(
+            valid=False,
+            message=f"Repo '{full_name}' not found or the GitHub app lacks access",
+        )
+    return ValidationResult(
+        valid=True,
+        message=full_name,
+        resolved={"repo_owner": owner, "repo_name": repo},
     )
 
 

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -140,21 +140,26 @@ def validate_slack_channel(value: str) -> ValidationResult:
 
 
 def validate_slack_group(name: str) -> ValidationResult:
-    """A Slack user-group / team name (used for SME groups + oncall)."""
-    raw = (name or "").strip().lstrip("@")
-    if not raw:
-        return ValidationResult(valid=False, message="Enter a group name")
+    """One or more Slack user-group handles/names (comma-separated) — used for SME
+    groups and the on-call DRI handles (e.g. "@as-dri"). Matches on either the
+    group name or its @handle; reports any that don't resolve."""
+    handles = [h.strip().lstrip("@") for h in (name or "").split(",") if h.strip()]
+    if not handles:
+        return ValidationResult(valid=False, message="Enter a group handle")
     try:
         client = _bot_client()
-        group_ids, failed = fetch_groupids_from_names([raw], client)
+        group_ids, failed = fetch_groupids_from_names(handles, client)
     except Exception as e:
         logger.warning("slack group validation failed: %s", e)
         return ValidationResult(valid=False, message="Couldn't reach Slack to verify")
-    if group_ids:
-        return ValidationResult(
-            valid=True, message=f"@{raw}", resolved={"group_id": group_ids[0]}
-        )
-    return ValidationResult(valid=False, message=f"No Slack user group named '{raw}'")
+    if failed:
+        missing = ", ".join(f"@{h}" for h in failed)
+        return ValidationResult(valid=False, message=f"No Slack user group: {missing}")
+    return ValidationResult(
+        valid=True,
+        message=", ".join(f"@{h}" for h in handles),
+        resolved={"group_ids": group_ids},
+    )
 
 
 def _first_confluence_credential(db_session: Session) -> dict | None:

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -93,15 +93,26 @@ def validate_slack_channel(value: str) -> ValidationResult:
     if channel_id:
         try:
             ch = client.conversations_info(channel=channel_id)["channel"]
+            # Scraping needs the bot IN the channel. It auto-joins PUBLIC channels
+            # on scrape, but can't self-join PRIVATE ones — those need an invite.
+            if ch.get("is_member"):
+                note = "the bot is already in this channel"
+            elif ch.get("is_private"):
+                note = "invite @Darwin — private channels can't be auto-joined"
+            else:
+                note = "the bot will auto-join this public channel when it scrapes"
             return ValidationResult(
                 valid=True,
-                message=f"#{ch['name']}",
+                message=f"#{ch['name']} · {note}",
                 resolved={"channel_id": ch["id"], "channel_name": ch["name"]},
             )
         except SlackApiError as e:
             return ValidationResult(
                 valid=False,
-                message=f"Channel not found or bot lacks access ({e.response.get('error')})",
+                message=(
+                    "Channel not found or the bot can't access it — for a private "
+                    f"channel, invite @Darwin first ({e.response.get('error')})"
+                ),
             )
 
     # Bare name. Slack has no name->channel lookup API, and every channel-read
@@ -134,7 +145,10 @@ def validate_slack_channel(value: str) -> ValidationResult:
         )
     return ValidationResult(
         valid=True,
-        message=f"#{name} · the bot will be added to this channel during onboarding",
+        message=(
+            f"#{name} · public channels auto-join when scraped; "
+            "invite @Darwin first if it's private"
+        ),
         resolved={"channel_name": name},
     )
 

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -33,6 +33,8 @@ logger = setup_logger()
 _MEMBER_CHANNEL_PAGES = 6  # ~6k channels the bot is in — plenty
 _MENTION_RE = re.compile(r"<#(C[A-Z0-9]+)(?:\|[^>]*)?>")
 _CHANNEL_ID_RE = re.compile(r"^C[A-Z0-9]{6,}$")
+# A pasted channel link, e.g. https://<ws>.slack.com/archives/C0123ABC/...
+_ARCHIVES_RE = re.compile(r"/archives/(C[A-Z0-9]+)")
 
 
 class ValidationResult(BaseModel):
@@ -72,8 +74,15 @@ def validate_slack_channel(value: str) -> ValidationResult:
         return ValidationResult(valid=False, message="Enter a channel")
 
     mention = _MENTION_RE.search(raw)
+    link = _ARCHIVES_RE.search(raw)
     channel_id = (
-        mention.group(1) if mention else (raw if _CHANNEL_ID_RE.match(raw) else None)
+        mention.group(1)
+        if mention
+        else link.group(1)
+        if link
+        else raw
+        if _CHANNEL_ID_RE.match(raw)
+        else None
     )
     try:
         client = _bot_client()

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -96,11 +96,14 @@ def validate_slack_channel(value: str) -> ValidationResult:
             )
 
     # Bare name. Slack has no name->channel lookup API, and every channel-read
-    # endpoint (conversations_info/history/replies) needs the ID, so there's no
-    # cheap indirect check. Rather than enumerate the whole org (tens of
-    # thousands of channels on Enterprise Grid), we search only the channels the
-    # BOT is a member of (users.conversations — a small set) — which is also the
-    # real precondition: the bot must be in the channel to answer and index it.
+    # endpoint (conversations_info/history/replies) needs the ID — so there's no
+    # cheap way to confirm a channel the bot isn't in yet, and enumerating the
+    # whole org (tens of thousands of channels on Enterprise Grid) is too costly.
+    # Crucially, the bot is only added to the channel DURING onboarding, so a
+    # brand-new channel legitimately isn't a member yet. We therefore never block
+    # on existence: we do a cheap membership check purely as a positive signal
+    # (and to resolve the real id/name when we can), and otherwise accept the
+    # name — provisioning uses the name, and the connector auto-joins on index.
     name = raw.lstrip("#").lower()
     try:
         ch = _find_channel_by_name(
@@ -110,18 +113,20 @@ def validate_slack_channel(value: str) -> ValidationResult:
             types="public_channel,private_channel",
         )
     except SlackApiError as e:
-        return ValidationResult(
-            valid=False, message=f"Couldn't verify channel ({e.response.get('error')})"
+        logger.warning(
+            "slack membership check failed for %s: %s", name, e.response.get("error")
         )
+        ch = None
     if ch:
         return ValidationResult(
             valid=True,
-            message=f"#{ch['name']}",
+            message=f"#{ch['name']} · the bot is already in this channel",
             resolved={"channel_id": ch["id"], "channel_name": ch["name"]},
         )
     return ValidationResult(
-        valid=False,
-        message=f"The Darwin bot isn't in #{name} yet — invite it to the channel, then re-check.",
+        valid=True,
+        message=f"#{name} · the bot will be added to this channel during onboarding",
+        resolved={"channel_name": name},
     )
 
 

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -273,6 +273,70 @@ def validate_github_repo(url: str, db_session: Session) -> ValidationResult:
     )
 
 
+def _first_jira_credential(db_session: Session) -> dict | None:
+    """Reuse an existing Jira connector's credential for the filter check."""
+    for cred in db_session.execute(select(Credential)).scalars():
+        cj = cred.credential_json or {}
+        if cj.get("jira_api_token"):
+            return cj
+    return None
+
+
+def jira_base_url(db_session: Session) -> str | None:
+    """Base URL of an existing Jira connector (onboarding reuses it — the
+    requester supplies only the filter, never the host/creds)."""
+    for connector in (
+        db_session.execute(
+            select(Connector).where(Connector.source == DocumentSource.JIRA)
+        )
+        .scalars()
+        .all()
+    ):
+        base = (connector.connector_specific_config or {}).get("jira_base_url")
+        if base:
+            return base
+    return None
+
+
+def validate_jira_filter(jql: str, db_session: Session) -> ValidationResult:
+    """Confirm a Jira JQL filter is valid and reachable with the stored Jira
+    credential (the same one provisioning will reuse).
+
+    The credential is only ever sent to the existing Jira connector's base URL,
+    never a user-supplied host. Errors are reported generically and logged by
+    exception type only, so a token or JQL-echoing API payload can't leak."""
+    raw = (jql or "").strip()
+    if not raw:
+        return ValidationResult(valid=False, message="Enter a Jira filter (JQL)")
+
+    base = jira_base_url(db_session)
+    creds = _first_jira_credential(db_session)
+    if base is None or creds is None:
+        return ValidationResult(
+            valid=True,
+            message="Filter unverified — no Jira connector/credential on file",
+            resolved={"jira_filter": raw},
+        )
+    try:
+        from jira import JIRA  # type: ignore[import-untyped]
+
+        token = creds["jira_api_token"]
+        if creds.get("jira_user_email"):
+            client = JIRA(basic_auth=(creds["jira_user_email"], token), server=base)
+        else:
+            client = JIRA(token_auth=token, server=base)
+        # maxResults=1 keeps this cheap; an invalid JQL or access error raises.
+        client.search_issues(raw, maxResults=1)
+    except Exception as e:
+        logger.info("jira filter validation failed: %s", type(e).__name__)
+        return ValidationResult(
+            valid=False, message="Invalid Jira filter (JQL) or no access"
+        )
+    return ValidationResult(
+        valid=True, message="Jira filter OK", resolved={"jira_filter": raw}
+    )
+
+
 def validate_docs_url(url: str) -> ValidationResult:
     """A docs.uipath.com root URL. We normalize to the product root (version /
     'latest' segment stripped) since the web connector auto-crawls all versions."""

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -190,6 +190,60 @@ def _allowed_confluence_hosts(db_session: Session) -> set[str]:
     return hosts
 
 
+def _confluence_base_url(db_session: Session) -> str | None:
+    """Wiki base URL of an existing Confluence connector (to build a client)."""
+    for connector in (
+        db_session.execute(
+            select(Connector).where(Connector.source == DocumentSource.CONFLUENCE)
+        )
+        .scalars()
+        .all()
+    ):
+        wiki_url = (connector.connector_specific_config or {}).get("wiki_page_url")
+        if wiki_url:
+            try:
+                base, _s, _p, _c = extract_confluence_keys_from_url(wiki_url)
+                return base
+            except Exception:
+                continue
+    return None
+
+
+def confluence_page_ancestors(
+    page_ids: list[str], db_session: Session
+) -> dict[str, list[str]]:
+    """Map each Confluence page id -> list of its ancestor page ids (best-effort).
+
+    Used to drop child pages when a parent is also provided (the connector
+    already recurses a page's descendants). Returns {} if we can't build a
+    client; individual failures resolve to an empty ancestor list."""
+    base = _confluence_base_url(db_session)
+    creds = _first_confluence_credential(db_session)
+    if not base or creds is None:
+        return {}
+    result: dict[str, list[str]] = {}
+    try:
+        from atlassian import Confluence  # type: ignore[import-untyped]
+
+        client = Confluence(
+            url=base,
+            username=creds["confluence_username"],
+            password=creds["confluence_access_token"],
+            cloud="atlassian.net" in base,
+        )
+        for pid in page_ids:
+            try:
+                ancestors = client.get_page_ancestors(pid) or []
+                result[pid] = [str(a["id"]) for a in ancestors if a.get("id")]
+            except Exception as e:
+                logger.info("confluence ancestors lookup failed for %s: %s", pid, e)
+                result[pid] = []
+    except Exception as e:
+        logger.info("confluence ancestry client unavailable: %s", e)
+        return {}
+    return result
+
+
 def validate_confluence_url(url: str, db_session: Session) -> ValidationResult:
     """Parse the wiki URL and confirm the space exists, using an existing
     Confluence connector's credentials — but ONLY if the URL's host matches an

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -259,14 +259,17 @@ def confluence_page_ancestors(
 
 
 def validate_confluence_url(url: str, db_session: Session) -> ValidationResult:
-    """Parse the wiki URL and confirm the space exists, using an existing
+    """Parse the wiki URL and confirm the target is reachable, using an existing
     Confluence connector's credentials — but ONLY if the URL's host matches an
-    existing Confluence connector (never send creds to an arbitrary host)."""
+    existing Confluence connector (never send creds to an arbitrary host).
+
+    Scope depends on the URL, mirroring the connector: a PAGE url scrapes that
+    page + all its child pages; a SPACE url scrapes the whole space."""
     raw = (url or "").strip()
     if not raw:
         return ValidationResult(valid=False, message="Enter a Confluence URL")
     try:
-        wiki_base, space, _page_id, is_cloud = extract_confluence_keys_from_url(raw)
+        wiki_base, space, page_id, is_cloud = extract_confluence_keys_from_url(raw)
     except ValueError:
         return ValidationResult(valid=False, message="Not a valid Confluence wiki URL")
 
@@ -279,14 +282,24 @@ def validate_confluence_url(url: str, db_session: Session) -> ValidationResult:
             message=f"Confluence host not allowed — must be one of {sorted(allowed_hosts)}",
         )
 
+    scope = (
+        "this page and all its child pages" if page_id else f"the whole '{space}' space"
+    )
+    resolved = {
+        "wiki_base": wiki_base,
+        "space": space,
+        "page_id": page_id,
+        "is_cloud": is_cloud,
+    }
+
     creds = _first_confluence_credential(db_session)
     # No creds, or no known Confluence host to vet against -> parse-only (never
     # send the token to an unvetted host).
     if creds is None or not allowed_hosts:
         return ValidationResult(
             valid=True,
-            message=f"Space '{space}' (existence unverified)",
-            resolved={"wiki_base": wiki_base, "space": space, "is_cloud": is_cloud},
+            message=f"Will scrape {scope} (access unverified)",
+            resolved=resolved,
         )
     try:
         from atlassian import Confluence  # type: ignore[import-untyped]
@@ -297,16 +310,19 @@ def validate_confluence_url(url: str, db_session: Session) -> ValidationResult:
             password=creds["confluence_access_token"],
             cloud=is_cloud,
         )
-        client.get_space(space)
+        # Verify the actual target: the page for a page url, else the space.
+        if page_id:
+            client.get_page_by_id(page_id)
+        else:
+            client.get_space(space)
     except Exception as e:
-        logger.info("confluence space validation failed for %s: %s", space, e)
+        logger.info("confluence validation failed for %s: %s", raw, e)
+        target = "Page" if page_id else f"Space '{space}'"
         return ValidationResult(
-            valid=False, message=f"Space '{space}' not found or inaccessible"
+            valid=False, message=f"{target} not found or inaccessible"
         )
     return ValidationResult(
-        valid=True,
-        message=f"Space '{space}'",
-        resolved={"wiki_base": wiki_base, "space": space, "is_cloud": is_cloud},
+        valid=True, message=f"Will scrape {scope}", resolved=resolved
     )
 
 

--- a/backend/danswer/onboarding/validation.py
+++ b/backend/danswer/onboarding/validation.py
@@ -1,0 +1,225 @@
+"""Inline validation for the self-serve onboarding form.
+
+Every source/handle a requester enters is validated against the live system
+before submission: Slack channels + user-groups via the bot's Slack client,
+Confluence spaces via an existing Confluence connector's credentials, and
+docs.uipath.com roots via the web-connector's version logic. Each validator is
+resilient — it distinguishes "invalid" from "couldn't check right now"."""
+import re
+from urllib.parse import urlparse
+
+from pydantic import BaseModel
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from danswer.configs.constants import DocumentSource
+from danswer.connectors.confluence.connector import extract_confluence_keys_from_url
+from danswer.connectors.web.connector import _uipath_product_prefix
+from danswer.danswerbot.slack.tokens import fetch_tokens
+from danswer.danswerbot.slack.utils import fetch_groupids_from_names
+from danswer.db.models import Connector
+from danswer.db.models import Credential
+from danswer.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Bounded scan for name->channel lookup (Slack has no name lookup API). Prefer a
+# #mention (carries the id) — that path is a single, exact call.
+_MAX_CHANNEL_PAGES = 12
+_MENTION_RE = re.compile(r"<#(C[A-Z0-9]+)(?:\|[^>]*)?>")
+_CHANNEL_ID_RE = re.compile(r"^C[A-Z0-9]{6,}$")
+
+
+class ValidationResult(BaseModel):
+    valid: bool
+    message: str
+    # Resolved canonical values (e.g. channel id/name, wiki base) when valid.
+    resolved: dict = {}
+
+
+def _bot_client() -> WebClient:
+    return WebClient(token=fetch_tokens().bot_token)
+
+
+def validate_slack_channel(value: str) -> ValidationResult:
+    """Accepts a #mention, a channel id, or a bare name. Resolves to the real
+    channel and confirms the bot can see it."""
+    raw = (value or "").strip()
+    if not raw:
+        return ValidationResult(valid=False, message="Enter a channel")
+
+    mention = _MENTION_RE.search(raw)
+    channel_id = (
+        mention.group(1) if mention else (raw if _CHANNEL_ID_RE.match(raw) else None)
+    )
+    try:
+        client = _bot_client()
+    except Exception as e:
+        logger.warning("slack client unavailable for validation: %s", e)
+        return ValidationResult(valid=False, message="Couldn't reach Slack to verify")
+
+    if channel_id:
+        try:
+            ch = client.conversations_info(channel=channel_id)["channel"]
+            return ValidationResult(
+                valid=True,
+                message=f"#{ch['name']}",
+                resolved={"channel_id": ch["id"], "channel_name": ch["name"]},
+            )
+        except SlackApiError as e:
+            return ValidationResult(
+                valid=False,
+                message=f"Channel not found or bot lacks access ({e.response.get('error')})",
+            )
+
+    name = raw.lstrip("#").lower()
+    cursor: str | None = None
+    try:
+        for _ in range(_MAX_CHANNEL_PAGES):
+            resp = client.conversations_list(
+                types="public_channel,private_channel",
+                limit=1000,
+                cursor=cursor,
+                exclude_archived=True,
+            )
+            for ch in resp.get("channels", []):
+                if ch.get("name", "").lower() == name:
+                    return ValidationResult(
+                        valid=True,
+                        message=f"#{ch['name']}",
+                        resolved={"channel_id": ch["id"], "channel_name": ch["name"]},
+                    )
+            meta = resp.get("response_metadata")
+            cursor = meta.get("next_cursor") if isinstance(meta, dict) else None
+            if not cursor:
+                break
+    except SlackApiError as e:
+        return ValidationResult(
+            valid=False, message=f"Couldn't verify channel ({e.response.get('error')})"
+        )
+    return ValidationResult(
+        valid=False,
+        message="Channel not found — paste it as a #mention to be sure",
+    )
+
+
+def validate_slack_group(name: str) -> ValidationResult:
+    """A Slack user-group / team name (used for SME groups + oncall)."""
+    raw = (name or "").strip().lstrip("@")
+    if not raw:
+        return ValidationResult(valid=False, message="Enter a group name")
+    try:
+        client = _bot_client()
+        group_ids, failed = fetch_groupids_from_names([raw], client)
+    except Exception as e:
+        logger.warning("slack group validation failed: %s", e)
+        return ValidationResult(valid=False, message="Couldn't reach Slack to verify")
+    if group_ids:
+        return ValidationResult(
+            valid=True, message=f"@{raw}", resolved={"group_id": group_ids[0]}
+        )
+    return ValidationResult(valid=False, message=f"No Slack user group named '{raw}'")
+
+
+def _first_confluence_credential(db_session: Session) -> dict | None:
+    """Reuse an existing Confluence connector's creds for inline space checks."""
+    for cred in db_session.execute(select(Credential)).scalars():
+        cj = cred.credential_json or {}
+        if cj.get("confluence_access_token") and cj.get("confluence_username"):
+            return cj
+    return None
+
+
+def _allowed_confluence_hosts(db_session: Session) -> set[str]:
+    """Hosts of existing Confluence connectors — the ONLY hosts we'll send our
+    stored Confluence token to (SSRF / credential-leak guard: never let a
+    user-supplied URL point the authenticated client at an arbitrary host)."""
+    hosts: set[str] = set()
+    for connector in (
+        db_session.execute(
+            select(Connector).where(Connector.source == DocumentSource.CONFLUENCE)
+        )
+        .scalars()
+        .all()
+    ):
+        wiki_url = (connector.connector_specific_config or {}).get("wiki_page_url")
+        netloc = urlparse(wiki_url).netloc.lower() if wiki_url else ""
+        if netloc:
+            hosts.add(netloc)
+    return hosts
+
+
+def validate_confluence_url(url: str, db_session: Session) -> ValidationResult:
+    """Parse the wiki URL and confirm the space exists, using an existing
+    Confluence connector's credentials — but ONLY if the URL's host matches an
+    existing Confluence connector (never send creds to an arbitrary host)."""
+    raw = (url or "").strip()
+    if not raw:
+        return ValidationResult(valid=False, message="Enter a Confluence URL")
+    try:
+        wiki_base, space, _page_id, is_cloud = extract_confluence_keys_from_url(raw)
+    except ValueError:
+        return ValidationResult(valid=False, message="Not a valid Confluence wiki URL")
+
+    # SSRF / credential-leak guard: only proceed against a known Confluence host.
+    host = urlparse(wiki_base).netloc.lower()
+    allowed_hosts = _allowed_confluence_hosts(db_session)
+    if allowed_hosts and host not in allowed_hosts:
+        return ValidationResult(
+            valid=False,
+            message=f"Confluence host not allowed — must be one of {sorted(allowed_hosts)}",
+        )
+
+    creds = _first_confluence_credential(db_session)
+    # No creds, or no known Confluence host to vet against -> parse-only (never
+    # send the token to an unvetted host).
+    if creds is None or not allowed_hosts:
+        return ValidationResult(
+            valid=True,
+            message=f"Space '{space}' (existence unverified)",
+            resolved={"wiki_base": wiki_base, "space": space, "is_cloud": is_cloud},
+        )
+    try:
+        from atlassian import Confluence  # type: ignore[import-untyped]
+
+        client = Confluence(
+            url=wiki_base,
+            username=creds["confluence_username"],
+            password=creds["confluence_access_token"],
+            cloud=is_cloud,
+        )
+        client.get_space(space)
+    except Exception as e:
+        logger.info("confluence space validation failed for %s: %s", space, e)
+        return ValidationResult(
+            valid=False, message=f"Space '{space}' not found or inaccessible"
+        )
+    return ValidationResult(
+        valid=True,
+        message=f"Space '{space}'",
+        resolved={"wiki_base": wiki_base, "space": space, "is_cloud": is_cloud},
+    )
+
+
+def validate_docs_url(url: str) -> ValidationResult:
+    """A docs.uipath.com root URL. We normalize to the product root (version /
+    'latest' segment stripped) since the web connector auto-crawls all versions."""
+    raw = (url or "").strip()
+    if not raw:
+        return ValidationResult(valid=False, message="Enter a docs URL")
+    if not re.match(r"^https?://docs\.uipath\.com/", raw):
+        return ValidationResult(valid=False, message="Must be a docs.uipath.com URL")
+    from urllib.parse import urlparse
+
+    parsed = urlparse(raw)
+    product_prefix = _uipath_product_prefix(parsed.path)
+    if not product_prefix.strip("/"):
+        return ValidationResult(valid=False, message="URL must include a product path")
+    root = f"{parsed.scheme}://{parsed.netloc}{product_prefix}"
+    return ValidationResult(
+        valid=True,
+        message=f"Will crawl all versions under {root}",
+        resolved={"root_url": root},
+    )

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -28,6 +28,7 @@ from danswer.db.onboarding import get_onboarding_request
 from danswer.db.onboarding import list_onboarding_requests
 from danswer.db.onboarding import list_onboarding_requests_for_user
 from danswer.db.onboarding import update_onboarding_status
+from danswer.onboarding.notify import notify_onboarding_submitted
 from danswer.onboarding.provision import provision_onboarding
 from danswer.onboarding.validation import validate_confluence_url
 from danswer.onboarding.validation import validate_docs_url
@@ -73,6 +74,8 @@ def submit_onboarding(
         requester_email=user.email if user else "system@darwin",
         payload=request.to_payload(),
     )
+    # Best-effort heads-up to the ops channel; never fail the submission on it.
+    notify_onboarding_submitted(created)
     return OnboardingRequestSnapshot.from_model(created)
 
 

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -26,6 +26,7 @@ from danswer.db.onboarding import create_onboarding_request
 from danswer.db.onboarding import get_onboarding_request
 from danswer.db.onboarding import list_onboarding_requests
 from danswer.db.onboarding import list_onboarding_requests_for_user
+from danswer.db.onboarding import update_onboarding_payload
 from danswer.db.onboarding import update_onboarding_status
 from danswer.onboarding.notify import notify_onboarding_submitted
 from danswer.onboarding.provision import provision_onboarding
@@ -195,6 +196,41 @@ def list_requests(
         OnboardingRequestSnapshot.from_model(r)
         for r in list_onboarding_requests(db_session)
     ]
+
+
+@admin_router.get("/{request_id}")
+def get_request(
+    request_id: int,
+    _: User | None = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    """Full request (incl. payload) so an admin can open it in the form to edit."""
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    return OnboardingRequestSnapshot.from_model(request)
+
+
+@admin_router.patch("/{request_id}")
+def edit_request(
+    request_id: int,
+    body: OnboardingSubmitRequest,
+    _: User | None = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    """Admin edits a PENDING request (fix gaps) before approving."""
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    if request.status != OnboardingStatus.PENDING.value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Request is '{request.status}', only pending requests can be edited.",
+        )
+    if not body.sources:
+        raise HTTPException(status_code=400, detail="At least one source is required.")
+    update_onboarding_payload(db_session, request, body.to_payload())
+    return OnboardingRequestSnapshot.from_model(request)
 
 
 @admin_router.post("/{request_id}/approve")

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -31,6 +31,7 @@ from danswer.db.onboarding import update_onboarding_status
 from danswer.onboarding.provision import provision_onboarding
 from danswer.onboarding.validation import validate_confluence_url
 from danswer.onboarding.validation import validate_docs_url
+from danswer.onboarding.validation import validate_github_repo
 from danswer.onboarding.validation import validate_slack_channel
 from danswer.onboarding.validation import validate_slack_group
 from danswer.onboarding.validation import ValidationResult
@@ -88,6 +89,8 @@ def validate_field(
         return validate_slack_group(request.value)
     if request.kind == "confluence":
         return validate_confluence_url(request.value, db_session)
+    if request.kind == "github":
+        return validate_github_repo(request.value, db_session)
     return validate_docs_url(request.value)
 
 

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -18,7 +18,6 @@ from danswer.configs.app_configs import DISABLE_AUTH
 from danswer.db.connector_credential_pair import get_connector_credential_pair_from_id
 from danswer.db.engine import get_session
 from danswer.db.models import IndexAttempt
-from danswer.db.models import IndexingStatus
 from danswer.db.models import OnboardingRequest
 from danswer.db.models import OnboardingStatus
 from danswer.db.models import User
@@ -175,14 +174,10 @@ def onboarding_status(
     ):
         raise HTTPException(status_code=403, detail="Not your onboarding request.")
 
+    # Status transitions (INDEXING -> COMPLETE / FAILED) are driven by the
+    # background finalizer, which also creates the doc set + assistant + Slack
+    # config once scraping finishes. This endpoint just reports current state.
     sources = _source_statuses(request, db_session)
-    # Auto-advance INDEXING -> COMPLETE once every source has indexed successfully.
-    if (
-        request.status == OnboardingStatus.INDEXING.value
-        and sources
-        and all(s.status == IndexingStatus.SUCCESS.value for s in sources)
-    ):
-        update_onboarding_status(db_session, request, OnboardingStatus.COMPLETE)
     return OnboardingStatusResponse(
         request_id=request.id, status=request.status, sources=sources
     )

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -184,6 +184,73 @@ def onboarding_status(
     )
 
 
+def _require_owner_or_admin(request: OnboardingRequest, user: User | None) -> None:
+    _require_user(user)
+    if (
+        user is not None
+        and user.role != UserRole.ADMIN
+        and request.requester_id != user.id
+    ):
+        raise HTTPException(status_code=403, detail="Not your onboarding request.")
+
+
+@basic_router.get("/{request_id}")
+def get_my_request(
+    request_id: int,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    """Full request (incl. payload) for the requester to open it in the form."""
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    _require_owner_or_admin(request, user)
+    return OnboardingRequestSnapshot.from_model(request)
+
+
+@basic_router.patch("/{request_id}")
+def edit_my_request(
+    request_id: int,
+    body: OnboardingSubmitRequest,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    """Requester edits their own request while it's still pending."""
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    _require_owner_or_admin(request, user)
+    if request.status != OnboardingStatus.PENDING.value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Request is '{request.status}', only pending requests can be edited.",
+        )
+    if not body.sources:
+        raise HTTPException(status_code=400, detail="At least one source is required.")
+    update_onboarding_payload(db_session, request, body.to_payload())
+    return OnboardingRequestSnapshot.from_model(request)
+
+
+@basic_router.post("/{request_id}/cancel")
+def cancel_my_request(
+    request_id: int,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    """Requester withdraws their own request while it's still pending."""
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    _require_owner_or_admin(request, user)
+    if request.status != OnboardingStatus.PENDING.value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Request is '{request.status}', only pending requests can be cancelled.",
+        )
+    update_onboarding_status(db_session, request, OnboardingStatus.CANCELLED)
+    return OnboardingRequestSnapshot.from_model(request)
+
+
 # --- admin approval ---------------------------------------------------------
 
 

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -26,8 +26,10 @@ from danswer.db.onboarding import create_onboarding_request
 from danswer.db.onboarding import get_onboarding_request
 from danswer.db.onboarding import list_onboarding_requests
 from danswer.db.onboarding import list_onboarding_requests_for_user
+from danswer.db.onboarding import set_help_thread_ts
 from danswer.db.onboarding import update_onboarding_payload
 from danswer.db.onboarding import update_onboarding_status
+from danswer.onboarding.notify import notify_client_submitted
 from danswer.onboarding.notify import notify_onboarding_submitted
 from danswer.onboarding.provision import provision_onboarding
 from danswer.onboarding.validation import validate_confluence_url
@@ -76,6 +78,11 @@ def submit_onboarding(
     )
     # Best-effort heads-up to the ops channel; never fail the submission on it.
     notify_onboarding_submitted(created)
+    # Customer-facing thread root: @mention the requester + tracking link. Persist
+    # the returned thread ts so lifecycle updates reply in the same thread.
+    thread_ts = notify_client_submitted(created)
+    if thread_ts:
+        set_help_thread_ts(db_session, created, thread_ts)
     return OnboardingRequestSnapshot.from_model(created)
 
 

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -1,0 +1,244 @@
+"""Self-serve onboarding API.
+
+- basic_router (/onboarding): any authenticated user may submit a request, watch
+  their own requests, validate form fields inline, and monitor scrape status.
+- admin_router (/admin/onboarding): admins list/approve/reject; approval triggers
+  provisioning (connectors + assistant + Slack config + high-priority indexing).
+"""
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from sqlalchemy import desc
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from danswer.auth.users import current_admin_user
+from danswer.auth.users import current_user
+from danswer.configs.app_configs import DISABLE_AUTH
+from danswer.db.connector_credential_pair import get_connector_credential_pair_from_id
+from danswer.db.engine import get_session
+from danswer.db.models import IndexAttempt
+from danswer.db.models import IndexingStatus
+from danswer.db.models import OnboardingRequest
+from danswer.db.models import OnboardingStatus
+from danswer.db.models import User
+from danswer.db.models import UserRole
+from danswer.db.onboarding import create_onboarding_request
+from danswer.db.onboarding import get_onboarding_request
+from danswer.db.onboarding import list_onboarding_requests
+from danswer.db.onboarding import list_onboarding_requests_for_user
+from danswer.db.onboarding import update_onboarding_status
+from danswer.onboarding.provision import provision_onboarding
+from danswer.onboarding.validation import validate_confluence_url
+from danswer.onboarding.validation import validate_docs_url
+from danswer.onboarding.validation import validate_slack_channel
+from danswer.onboarding.validation import validate_slack_group
+from danswer.onboarding.validation import ValidationResult
+from danswer.server.features.onboarding.models import DecisionRequest
+from danswer.server.features.onboarding.models import OnboardingRequestSnapshot
+from danswer.server.features.onboarding.models import OnboardingStatusResponse
+from danswer.server.features.onboarding.models import OnboardingSubmitRequest
+from danswer.server.features.onboarding.models import SourceStatus
+from danswer.server.features.onboarding.models import ValidateRequest
+
+basic_router = APIRouter(prefix="/onboarding")
+admin_router = APIRouter(prefix="/admin/onboarding")
+
+
+def _require_user(user: User | None) -> None:
+    """Onboarding is a human workflow — reject anonymous / API-key (service)
+    callers. `current_user` returns None for API-key callers and when auth is
+    globally disabled; allow None only in the latter (dev) case."""
+    if user is None and not DISABLE_AUTH:
+        raise HTTPException(status_code=401, detail="Authentication required.")
+
+
+# --- submit + validate + monitor (any authed user) --------------------------
+
+
+@basic_router.post("")
+def submit_onboarding(
+    request: OnboardingSubmitRequest,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    _require_user(user)
+    if not request.sources:
+        raise HTTPException(status_code=400, detail="At least one source is required.")
+    created = create_onboarding_request(
+        db_session=db_session,
+        requester_id=user.id if user else None,
+        requester_email=user.email if user else "system@darwin",
+        payload=request.to_payload(),
+    )
+    return OnboardingRequestSnapshot.from_model(created)
+
+
+@basic_router.post("/validate")
+def validate_field(
+    request: ValidateRequest,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> ValidationResult:
+    """Inline validation for a single form field."""
+    _require_user(user)
+    if request.kind == "slack_channel":
+        return validate_slack_channel(request.value)
+    if request.kind == "slack_group":
+        return validate_slack_group(request.value)
+    if request.kind == "confluence":
+        return validate_confluence_url(request.value, db_session)
+    return validate_docs_url(request.value)
+
+
+@basic_router.get("/default-prompt")
+def default_prompt(
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> dict:
+    """The template prompt the form prefills (the Orchestrator assistant's prompt);
+    the requester can edit it before submitting."""
+    from danswer.db.persona import get_persona_by_name
+
+    template = get_persona_by_name("Orchestrator", user, db_session)
+    if template and template.prompts:
+        p = template.prompts[0]
+        return {"system_prompt": p.system_prompt, "task_prompt": p.task_prompt}
+    return {"system_prompt": "", "task_prompt": ""}
+
+
+@basic_router.get("/mine")
+def my_onboarding_requests(
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> list[OnboardingRequestSnapshot]:
+    if user is None:
+        return []
+    return [
+        OnboardingRequestSnapshot.from_model(r)
+        for r in list_onboarding_requests_for_user(db_session, user.id)
+    ]
+
+
+def _source_statuses(
+    request: OnboardingRequest, db_session: Session
+) -> list[SourceStatus]:
+    """Per-cc_pair scrape status for the request (from the latest IndexAttempt)."""
+    statuses: list[SourceStatus] = []
+    for cc_pair_id in request.cc_pair_ids or []:
+        cc_pair = get_connector_credential_pair_from_id(cc_pair_id, db_session)
+        if cc_pair is None:
+            continue
+        latest = db_session.execute(
+            select(IndexAttempt)
+            .where(IndexAttempt.connector_id == cc_pair.connector_id)
+            .where(IndexAttempt.credential_id == cc_pair.credential_id)
+            .order_by(desc(IndexAttempt.time_created))
+            .limit(1)
+        ).scalar_one_or_none()
+        statuses.append(
+            SourceStatus(
+                cc_pair_id=cc_pair_id,
+                name=cc_pair.name,
+                status=latest.status.value if latest else "not_started",
+                docs_indexed=(latest.total_docs_indexed or 0) if latest else 0,
+                error_msg=latest.error_msg if latest else None,
+            )
+        )
+    return statuses
+
+
+@basic_router.get("/{request_id}/status")
+def onboarding_status(
+    request_id: int,
+    user: User | None = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingStatusResponse:
+    _require_user(user)
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    # Requester or an admin may view.
+    if (
+        user is not None
+        and user.role != UserRole.ADMIN
+        and request.requester_id != user.id
+    ):
+        raise HTTPException(status_code=403, detail="Not your onboarding request.")
+
+    sources = _source_statuses(request, db_session)
+    # Auto-advance INDEXING -> COMPLETE once every source has indexed successfully.
+    if (
+        request.status == OnboardingStatus.INDEXING.value
+        and sources
+        and all(s.status == IndexingStatus.SUCCESS.value for s in sources)
+    ):
+        update_onboarding_status(db_session, request, OnboardingStatus.COMPLETE)
+    return OnboardingStatusResponse(
+        request_id=request.id, status=request.status, sources=sources
+    )
+
+
+# --- admin approval ---------------------------------------------------------
+
+
+@admin_router.get("")
+def list_requests(
+    _: User | None = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> list[OnboardingRequestSnapshot]:
+    return [
+        OnboardingRequestSnapshot.from_model(r)
+        for r in list_onboarding_requests(db_session)
+    ]
+
+
+@admin_router.post("/{request_id}/approve")
+def approve_request(
+    request_id: int,
+    admin: User | None = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    if request.status != OnboardingStatus.PENDING.value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Request is '{request.status}', only pending requests can be approved.",
+        )
+    if admin is None:
+        raise HTTPException(
+            status_code=403, detail="Admin identity required to approve."
+        )
+    try:
+        provision_onboarding(request, admin, db_session)
+    except Exception as e:
+        # provision_onboarding already marked the request FAILED; surface the error.
+        raise HTTPException(status_code=500, detail=f"Provisioning failed: {e}")
+    return OnboardingRequestSnapshot.from_model(request)
+
+
+@admin_router.post("/{request_id}/reject")
+def reject_request(
+    request_id: int,
+    decision: DecisionRequest,
+    admin: User | None = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> OnboardingRequestSnapshot:
+    request = get_onboarding_request(db_session, request_id)
+    if request is None:
+        raise HTTPException(status_code=404, detail="Onboarding request not found.")
+    if request.status != OnboardingStatus.PENDING.value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Request is '{request.status}', only pending requests can be rejected.",
+        )
+    update_onboarding_status(
+        db_session,
+        request,
+        OnboardingStatus.REJECTED,
+        approver_id=admin.id if admin else None,
+        decision_reason=decision.reason,
+    )
+    return OnboardingRequestSnapshot.from_model(request)

--- a/backend/danswer/server/features/onboarding/api.py
+++ b/backend/danswer/server/features/onboarding/api.py
@@ -32,6 +32,7 @@ from danswer.onboarding.provision import provision_onboarding
 from danswer.onboarding.validation import validate_confluence_url
 from danswer.onboarding.validation import validate_docs_url
 from danswer.onboarding.validation import validate_github_repo
+from danswer.onboarding.validation import validate_jira_filter
 from danswer.onboarding.validation import validate_slack_channel
 from danswer.onboarding.validation import validate_slack_group
 from danswer.onboarding.validation import ValidationResult
@@ -91,6 +92,8 @@ def validate_field(
         return validate_confluence_url(request.value, db_session)
     if request.kind == "github":
         return validate_github_repo(request.value, db_session)
+    if request.kind == "jira":
+        return validate_jira_filter(request.value, db_session)
     return validate_docs_url(request.value)
 
 

--- a/backend/danswer/server/features/onboarding/models.py
+++ b/backend/danswer/server/features/onboarding/models.py
@@ -28,6 +28,8 @@ class SmeOption(BaseModel):
 class OncallOption(BaseModel):
     enabled: bool = False
     schedule: str = ""  # opsgenie schedule name to tag on "need more help"
+    # comma-separated Slack user-group handles / emails to tag as DRI (e.g. @as-dri)
+    handles: str = ""
 
 
 class JiraOption(BaseModel):

--- a/backend/danswer/server/features/onboarding/models.py
+++ b/backend/danswer/server/features/onboarding/models.py
@@ -14,8 +14,9 @@ class ChannelRef(BaseModel):
 
 class OnboardingSourceModel(BaseModel):
     # Priority is the order in the sources list (index 0 = highest).
-    type: Literal["web", "confluence", "github", "slack"]
-    value: str  # docs root URL / confluence URL / github repo URL / slack channel name
+    type: Literal["web", "confluence", "github", "slack", "jira"]
+    # docs root URL / confluence URL / github repo URL / slack channel / jira JQL
+    value: str
     label: str | None = None
 
 
@@ -85,7 +86,9 @@ class OnboardingRequestSnapshot(BaseModel):
 
 
 class ValidateRequest(BaseModel):
-    kind: Literal["slack_channel", "slack_group", "confluence", "github", "docs"]
+    kind: Literal[
+        "slack_channel", "slack_group", "confluence", "github", "jira", "docs"
+    ]
     value: str
 
 

--- a/backend/danswer/server/features/onboarding/models.py
+++ b/backend/danswer/server/features/onboarding/models.py
@@ -1,0 +1,107 @@
+"""Request/response models for the self-serve onboarding API."""
+import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+from danswer.db.models import OnboardingRequest
+
+
+class ChannelRef(BaseModel):
+    channel_id: str
+    channel_name: str
+
+
+class OnboardingSourceModel(BaseModel):
+    # Priority is the order in the sources list (index 0 = highest).
+    type: Literal["web", "confluence", "github", "slack"]
+    value: str  # docs root URL / confluence URL / github repo URL / slack channel name
+    label: str | None = None
+
+
+class SmeOption(BaseModel):
+    enabled: bool = False
+    group_name: str = ""  # comma-separated Slack user-group names/@handles
+
+
+class OncallOption(BaseModel):
+    enabled: bool = False
+    schedule: str = ""  # opsgenie schedule name to tag on "need more help"
+
+
+class JiraOption(BaseModel):
+    enabled: bool = False
+    project_key: str = ""
+    issue_type: str = ""
+    component: str = ""
+
+
+class OnboardingSubmitRequest(BaseModel):
+    team_name: str
+    channel: ChannelRef
+    response_type: Literal["citations", "quotes"] = "citations"
+    respond_tag_only: bool = False
+    system_prompt: str = ""
+    task_prompt: str = ""
+    sme: SmeOption = SmeOption()
+    oncall: OncallOption = OncallOption()
+    jira: JiraOption = JiraOption()
+    sources: list[OnboardingSourceModel]
+
+    def to_payload(self) -> dict:
+        return self.dict()
+
+
+class OnboardingRequestSnapshot(BaseModel):
+    id: int
+    requester_email: str
+    status: str
+    payload: dict
+    decision_reason: str | None
+    error_msg: str | None
+    persona_id: int | None
+    document_set_id: int | None
+    slack_bot_config_id: int | None
+    cc_pair_ids: list[int] | None
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    @classmethod
+    def from_model(cls, r: OnboardingRequest) -> "OnboardingRequestSnapshot":
+        return cls(
+            id=r.id,
+            requester_email=r.requester_email,
+            status=r.status,
+            payload=r.payload,
+            decision_reason=r.decision_reason,
+            error_msg=r.error_msg,
+            persona_id=r.persona_id,
+            document_set_id=r.document_set_id,
+            slack_bot_config_id=r.slack_bot_config_id,
+            cc_pair_ids=r.cc_pair_ids,
+            created_at=r.created_at,
+            updated_at=r.updated_at,
+        )
+
+
+class ValidateRequest(BaseModel):
+    kind: Literal["slack_channel", "slack_group", "confluence", "docs"]
+    value: str
+
+
+class DecisionRequest(BaseModel):
+    reason: str | None = None
+
+
+class SourceStatus(BaseModel):
+    cc_pair_id: int
+    name: str
+    status: str  # IndexingStatus value, or "not_started"
+    docs_indexed: int
+    error_msg: str | None
+
+
+class OnboardingStatusResponse(BaseModel):
+    request_id: int
+    status: str
+    sources: list[SourceStatus]

--- a/backend/danswer/server/features/onboarding/models.py
+++ b/backend/danswer/server/features/onboarding/models.py
@@ -85,7 +85,7 @@ class OnboardingRequestSnapshot(BaseModel):
 
 
 class ValidateRequest(BaseModel):
-    kind: Literal["slack_channel", "slack_group", "confluence", "docs"]
+    kind: Literal["slack_channel", "slack_group", "confluence", "github", "docs"]
     value: str
 
 

--- a/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
+++ b/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
@@ -5,15 +5,22 @@ from danswer.connectors.slack.utils import normalize_slack_link
 from danswer.connectors.slack.utils import resolve_workspace_subdomain
 
 
+class _FakeResp(dict):
+    """Minimal stand-in for slack_sdk's SlackResponse (dict-like + validate())."""
+
+    def validate(self) -> "_FakeResp":
+        return self
+
+
 class _FakeClient:
     def __init__(self, permalink: str | None = None, error: str | None = None):
         self._permalink = permalink
         self._error = error
 
-    def chat_getPermalink(self, channel: str, message_ts: str) -> dict:
+    def chat_getPermalink(self, channel: str, message_ts: str) -> _FakeResp:
         if self._error is not None:
             raise SlackApiError(self._error, {"ok": False, "error": self._error})
-        return {"ok": True, "permalink": self._permalink}
+        return _FakeResp({"ok": True, "permalink": self._permalink})
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
+++ b/backend/tests/unit/danswer/connectors/slack/test_normalize_slack_link.py
@@ -1,0 +1,103 @@
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from danswer.connectors.slack.utils import normalize_slack_link
+from danswer.connectors.slack.utils import resolve_workspace_subdomain
+
+
+class _FakeClient:
+    def __init__(self, permalink: str | None = None, error: str | None = None):
+        self._permalink = permalink
+        self._error = error
+
+    def chat_getPermalink(self, channel: str, message_ts: str) -> dict:
+        if self._error is not None:
+            raise SlackApiError(self._error, {"ok": False, "error": self._error})
+        return {"ok": True, "permalink": self._permalink}
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # The bug: workspace display name "Product" -> dead product.slack.com.
+        (
+            "https://Product.slack.com/archives/C02EF2C5KS8/p1712595481616829",
+            "https://uipath-product.slack.com/archives/C02EF2C5KS8/p1712595481616829",
+        ),
+        # Trailing space variant seen in the data ("Product ").
+        (
+            "https://Product .slack.com/archives/C02/p1?thread_ts=1712595481.616829",
+            "https://uipath-product.slack.com/archives/C02/p1?thread_ts=1712595481.616829",
+        ),
+        # Case-insensitive match.
+        (
+            "https://product.slack.com/archives/C02/p1",
+            "https://uipath-product.slack.com/archives/C02/p1",
+        ),
+        # Idempotent: already-canonical link is untouched.
+        (
+            "https://uipath-product.slack.com/archives/C02/p1",
+            "https://uipath-product.slack.com/archives/C02/p1",
+        ),
+        # Genuinely different workspaces must NOT be rewritten.
+        (
+            "https://uipath-customer-ops.slack.com/archives/C99/p2",
+            "https://uipath-customer-ops.slack.com/archives/C99/p2",
+        ),
+        (
+            "https://uipath-marketing.slack.com/archives/C99/p2",
+            "https://uipath-marketing.slack.com/archives/C99/p2",
+        ),
+        # Non-Slack links pass through unchanged (even if a path says "product").
+        (
+            "https://docs.uipath.com/product/latest",
+            "https://docs.uipath.com/product/latest",
+        ),
+        # Only the host is rewritten, not a matching path segment.
+        (
+            "https://Product.slack.com/archives/product/p1",
+            "https://uipath-product.slack.com/archives/product/p1",
+        ),
+    ],
+)
+def test_normalize_slack_link(raw: str, expected: str) -> None:
+    assert normalize_slack_link(raw) == expected
+
+
+def test_normalize_slack_link_empty() -> None:
+    assert normalize_slack_link("") == ""
+
+
+def test_resolve_workspace_subdomain_from_permalink() -> None:
+    client = _FakeClient(
+        permalink="https://uipath-product.slack.com/archives/C02/p1712595481616829"
+    )
+    assert (
+        resolve_workspace_subdomain(client, "C02", "1712595481.616829", fallback="X")  # type: ignore[arg-type]
+        == "uipath-product"
+    )
+
+
+def test_resolve_workspace_subdomain_other_workspace() -> None:
+    client = _FakeClient(
+        permalink="https://uipath-customer-ops.slack.com/archives/C99/p1"
+    )
+    assert (
+        resolve_workspace_subdomain(client, "C99", "1.1", fallback="X")  # type: ignore[arg-type]
+        == "uipath-customer-ops"
+    )
+
+
+@pytest.mark.parametrize(
+    "client",
+    [
+        _FakeClient(error="channel_not_found"),  # API error -> fallback
+        _FakeClient(permalink=""),  # empty permalink -> fallback
+        _FakeClient(permalink="https://example.com/not-slack"),  # non-slack -> fallback
+    ],
+)
+def test_resolve_workspace_subdomain_falls_back(client: _FakeClient) -> None:
+    assert (
+        resolve_workspace_subdomain(client, "C1", "1.1", fallback="uipath-product")  # type: ignore[arg-type]
+        == "uipath-product"
+    )

--- a/backend/tests/unit/danswer/onboarding/test_finalizer.py
+++ b/backend/tests/unit/danswer/onboarding/test_finalizer.py
@@ -281,11 +281,24 @@ def test_still_indexing_does_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
 # --- finalize_onboarding: idempotent, crash-safe artifact creation ----------
 
 
+class _ToolQuery:
+    """Stub for db_session.query(Tool).filter(...).first() -> the SearchTool."""
+
+    def filter(self, *a: object, **k: object) -> "_ToolQuery":
+        return self
+
+    def first(self) -> object:
+        return SimpleNamespace(id=99, in_code_tool_id="SearchTool")
+
+
 class _FakeSession:
     """Records rollback so we can assert the read txn is dropped before begin()."""
 
     def __init__(self, order: list) -> None:
         self._order = order
+
+    def query(self, *a: object, **k: object) -> _ToolQuery:
+        return _ToolQuery()
 
     def rollback(self) -> None:
         self._order.append("rollback")
@@ -345,6 +358,7 @@ def _wire_finalize(
 
     def _persona(**kw: object) -> object:
         order.append("persona")
+        calls["persona_tool_ids"] = kw.get("tool_ids")
         if fail_on == "persona":
             raise RuntimeError("boom persona")
         return SimpleNamespace(id=202)
@@ -392,6 +406,9 @@ def test_finalize_creates_all_artifacts_in_order(
     assert req.slack_bot_config_id == 303
     assert req.status == OnboardingStatus.COMPLETE.value
     assert calls["notified"] == 1
+    # The assistant must get the SearchTool, else it has the doc set but can't
+    # actually search it.
+    assert calls["persona_tool_ids"] == [99]
 
 
 def test_finalize_drops_read_txn_before_document_set(

--- a/backend/tests/unit/danswer/onboarding/test_finalizer.py
+++ b/backend/tests/unit/danswer/onboarding/test_finalizer.py
@@ -1,8 +1,9 @@
 """Unit tests for the background onboarding finalizer state machine.
 
-Covers `_source_index_state` (reading per-source scrape status) and
-`finalize_ready_onboarding_requests` (finalize on success, flag failure once,
-recover a previously-FAILED request) — positive and negative paths."""
+Covers `_source_index_state` (reading per-source scrape status, incl. the
+in-progress flag) and `finalize_ready_onboarding_requests` (finalize on success,
+flag failure once, recover a previously-FAILED request, and flip a re-indexing
+FAILED request back to INDEXING) — positive and negative paths."""
 from types import SimpleNamespace
 
 import pytest
@@ -53,9 +54,10 @@ def test_state_all_success(monkeypatch: pytest.MonkeyPatch) -> None:
     sess = _Session(
         [_attempt(IndexingStatus.SUCCESS), _attempt(IndexingStatus.SUCCESS)]
     )
-    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    all_indexed, failures, in_progress = provision._source_index_state(req, sess)  # type: ignore[arg-type]
     assert all_indexed is True
     assert failures == []
+    assert in_progress is False
 
 
 def test_state_one_failed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,34 +66,58 @@ def test_state_one_failed(monkeypatch: pytest.MonkeyPatch) -> None:
     sess = _Session(
         [_attempt(IndexingStatus.SUCCESS), _attempt(IndexingStatus.FAILED, "boom")]
     )
-    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    all_indexed, failures, in_progress = provision._source_index_state(req, sess)  # type: ignore[arg-type]
     assert all_indexed is False
     assert len(failures) == 1 and "boom" in failures[0]
+    assert in_progress is False
 
 
-def test_state_in_progress_is_not_done(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_state_in_progress_flag_when_running(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_cc(monkeypatch)
     req = SimpleNamespace(cc_pair_ids=[10, 11])
     sess = _Session(
         [_attempt(IndexingStatus.SUCCESS), _attempt(IndexingStatus.IN_PROGRESS)]
     )
-    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    all_indexed, failures, in_progress = provision._source_index_state(req, sess)  # type: ignore[arg-type]
     assert all_indexed is False  # still scraping
     assert failures == []  # not a failure either
+    assert in_progress is True
 
 
-def test_state_no_attempt_yet_is_not_done(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_state_in_progress_flag_when_not_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A freshly-queued (NOT_STARTED) attempt also counts as in-progress: it's
+    # what a just-triggered re-index looks like before a worker picks it up.
+    _patch_cc(monkeypatch)
+    req = SimpleNamespace(cc_pair_ids=[10])
+    sess = _Session([_attempt(IndexingStatus.NOT_STARTED)])
+    all_indexed, failures, in_progress = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    assert all_indexed is False
+    assert failures == []
+    assert in_progress is True
+
+
+def test_state_no_attempt_yet_is_not_in_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No attempt row at all (None) is neither done nor actively running.
     _patch_cc(monkeypatch)
     req = SimpleNamespace(cc_pair_ids=[10])
     sess = _Session([None])  # no index attempt row yet
-    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    all_indexed, failures, in_progress = provision._source_index_state(req, sess)  # type: ignore[arg-type]
     assert all_indexed is False
     assert failures == []
+    assert in_progress is False
 
 
 def test_state_no_cc_pairs() -> None:
     req = SimpleNamespace(cc_pair_ids=[])
-    assert provision._source_index_state(req, None) == (False, [])  # type: ignore[arg-type]
+    assert provision._source_index_state(req, None) == (  # type: ignore[arg-type]
+        False,
+        [],
+        False,
+    )
 
 
 # --- finalize_ready_onboarding_requests ------------------------------------
@@ -102,7 +128,7 @@ def _wire(
     *,
     indexing: list,
     failed: list,
-    state,  # callable(request) -> (all_indexed, failures)
+    state,  # callable(request) -> (all_indexed, failures, in_progress)
 ) -> dict:
     """Patch the finalizer's collaborators and capture what it does."""
     calls: dict = {"finalized": [], "failed_notified": [], "status": []}
@@ -138,7 +164,9 @@ def _req(id_: int, status: OnboardingStatus) -> SimpleNamespace:
 
 def test_finalizes_when_all_indexed(monkeypatch: pytest.MonkeyPatch) -> None:
     req = _req(1, OnboardingStatus.INDEXING)
-    calls = _wire(monkeypatch, indexing=[req], failed=[], state=lambda r: (True, []))
+    calls = _wire(
+        monkeypatch, indexing=[req], failed=[], state=lambda r: (True, [], False)
+    )
     provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
     assert calls["finalized"] == [1]
     assert calls["failed_notified"] == []
@@ -147,7 +175,10 @@ def test_finalizes_when_all_indexed(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_flags_failure_once(monkeypatch: pytest.MonkeyPatch) -> None:
     req = _req(2, OnboardingStatus.INDEXING)
     calls = _wire(
-        monkeypatch, indexing=[req], failed=[], state=lambda r: (False, ["src-1: boom"])
+        monkeypatch,
+        indexing=[req],
+        failed=[],
+        state=lambda r: (False, ["src-1: boom"], False),
     )
     provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
     assert (2, OnboardingStatus.FAILED.value) in calls["status"]
@@ -156,30 +187,309 @@ def test_flags_failure_once(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_already_failed_not_renotified(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A FAILED request that is still failing must not spam notifications.
+    # A FAILED request that is still failing (nothing re-indexing) must not spam
+    # notifications and must stay FAILED.
     req = _req(3, OnboardingStatus.FAILED)
     calls = _wire(
-        monkeypatch, indexing=[], failed=[req], state=lambda r: (False, ["still bad"])
+        monkeypatch,
+        indexing=[],
+        failed=[req],
+        state=lambda r: (False, ["still bad"], False),
     )
     provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
     assert calls["failed_notified"] == []
     assert calls["finalized"] == []
+    assert calls["status"] == []  # no transition
 
 
 def test_recovers_previously_failed(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A FAILED request whose sources now succeed is finalized — no restart needed.
+    # A FAILED request whose sources now all succeed is finalized — no restart.
     req = _req(4, OnboardingStatus.FAILED)
-    calls = _wire(monkeypatch, indexing=[], failed=[req], state=lambda r: (True, []))
+    calls = _wire(
+        monkeypatch, indexing=[], failed=[req], state=lambda r: (True, [], False)
+    )
     provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
     assert calls["finalized"] == [4]
 
 
+def test_failed_reindexing_flips_back_to_indexing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A FAILED request that is now re-indexing (sources fixed + re-run) with
+    # nothing currently failing flips back to INDEXING so the requester sees
+    # progress — not finalized yet, not re-notified.
+    req = _req(8, OnboardingStatus.FAILED)
+    calls = _wire(
+        monkeypatch, indexing=[], failed=[req], state=lambda r: (False, [], True)
+    )
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert (8, OnboardingStatus.INDEXING.value) in calls["status"]
+    assert calls["finalized"] == []
+    assert calls["failed_notified"] == []
+
+
+def test_failed_partial_reindex_flips_to_indexing_despite_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # In-progress WINS over a failure: a FAILED request with a source still
+    # scraping flips to INDEXING (work is happening) even though another source's
+    # latest attempt is failed — no re-notify. The failure verdict is deferred
+    # until everything settles.
+    req = _req(9, OnboardingStatus.FAILED)
+    calls = _wire(
+        monkeypatch,
+        indexing=[],
+        failed=[req],
+        state=lambda r: (False, ["src-2: still bad"], True),
+    )
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert (9, OnboardingStatus.INDEXING.value) in calls["status"]
+    assert calls["failed_notified"] == []
+    assert calls["finalized"] == []
+
+
+def test_indexing_with_a_failure_but_still_running_stays_indexing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A source failed while a sibling is still scraping: don't prematurely flag
+    # FAILED — stay INDEXING and wait for everything to settle.
+    req = _req(10, OnboardingStatus.INDEXING)
+    calls = _wire(
+        monkeypatch,
+        indexing=[req],
+        failed=[],
+        state=lambda r: (False, ["src-1: boom"], True),
+    )
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert calls["status"] == []  # already INDEXING, no flip needed
+    assert calls["failed_notified"] == []  # not flagged failed yet
+    assert calls["finalized"] == []
+
+
 def test_still_indexing_does_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     req = _req(5, OnboardingStatus.INDEXING)
-    calls = _wire(monkeypatch, indexing=[req], failed=[], state=lambda r: (False, []))
+    calls = _wire(
+        monkeypatch, indexing=[req], failed=[], state=lambda r: (False, [], True)
+    )
     provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
     assert calls["finalized"] == []
     assert calls["failed_notified"] == []
+    assert calls["status"] == []
+
+
+# --- finalize_onboarding: idempotent, crash-safe artifact creation ----------
+
+
+class _FakeSession:
+    """Records rollback so we can assert the read txn is dropped before begin()."""
+
+    def __init__(self, order: list) -> None:
+        self._order = order
+
+    def rollback(self) -> None:
+        self._order.append("rollback")
+
+    def commit(self) -> None:
+        pass
+
+
+def _finalize_request(**over: object) -> SimpleNamespace:
+    base: dict = dict(
+        id=1,
+        payload={"team_name": "T", "sources": [], "response_type": "citations"},
+        cc_pair_ids=[1, 2],
+        approver_id=1,
+        requester_id=2,
+        document_set_id=None,
+        persona_id=None,
+        slack_bot_config_id=None,
+        status=OnboardingStatus.INDEXING.value,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _wire_finalize(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    order: list,
+    fail_on: str | None = None,
+    notify_raises: bool = False,
+) -> dict:
+    """Patch finalize_onboarding's collaborators. Records step order; can inject a
+    failure at a given step; set_provisioned_ids writes ids back onto the request
+    so a follow-up call sees the resumed (checkpointed) state."""
+    calls: dict = {"notified": 0}
+    monkeypatch.setattr(
+        provision, "_finalize_owner", lambda r, db: SimpleNamespace(id=9)
+    )
+
+    def _set_ids(db: object, req: object, **kw: object) -> object:
+        for k, v in kw.items():
+            setattr(req, k, v)
+        return req
+
+    monkeypatch.setattr(provision, "set_provisioned_ids", _set_ids)
+
+    def _doc(req: object, uid: object, db: object) -> tuple:
+        order.append("doc_set")
+        if fail_on == "doc_set":
+            raise RuntimeError("boom doc_set")
+        return SimpleNamespace(id=101), []
+
+    monkeypatch.setattr(provision, "insert_document_set", _doc)
+    monkeypatch.setattr(
+        provision, "_build_prompt", lambda p, o, db: SimpleNamespace(id=2)
+    )
+
+    def _persona(**kw: object) -> object:
+        order.append("persona")
+        if fail_on == "persona":
+            raise RuntimeError("boom persona")
+        return SimpleNamespace(id=202)
+
+    monkeypatch.setattr(provision, "upsert_persona", _persona)
+    monkeypatch.setattr(provision, "_build_channel_config", lambda p, ps: {})
+    monkeypatch.setattr(provision, "_prioritized_sources", lambda s: [])
+
+    def _slack(**kw: object) -> object:
+        order.append("slack")
+        if fail_on == "slack":
+            raise RuntimeError("boom slack")
+        return SimpleNamespace(id=303)
+
+    monkeypatch.setattr(provision, "insert_slack_bot_config", _slack)
+
+    def _status(db: object, req: object, status: object, **kw: object) -> object:
+        req.status = status.value  # type: ignore[attr-defined]
+        order.append(f"status:{status.value}")
+        return req
+
+    monkeypatch.setattr(provision, "update_onboarding_status", _status)
+
+    def _notify(req: object) -> None:
+        calls["notified"] += 1
+        if notify_raises:
+            raise RuntimeError("slack down")
+
+    monkeypatch.setattr(provision, "notify_onboarding_complete", _notify)
+    return calls
+
+
+def test_finalize_creates_all_artifacts_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Happy path: rollback first (so insert_document_set can begin() its own
+    # transaction), then doc set -> persona -> slack -> COMPLETE, notify once.
+    order: list[str] = []
+    calls = _wire_finalize(monkeypatch, order=order)
+    req = _finalize_request()
+    provision.finalize_onboarding(req, _FakeSession(order))  # type: ignore[arg-type]
+    assert order == ["rollback", "doc_set", "persona", "slack", "status:complete"]
+    assert req.document_set_id == 101
+    assert req.persona_id == 202
+    assert req.slack_bot_config_id == 303
+    assert req.status == OnboardingStatus.COMPLETE.value
+    assert calls["notified"] == 1
+
+
+def test_finalize_drops_read_txn_before_document_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression: insert_document_set calls db_session.begin(), which raises if a
+    # transaction is already active (the finalizer opened one doing its reads).
+    # The rollback must happen before the document set is created.
+    order: list[str] = []
+    _wire_finalize(monkeypatch, order=order)
+    provision.finalize_onboarding(_finalize_request(), _FakeSession(order))  # type: ignore[arg-type]
+    assert order.index("rollback") < order.index("doc_set")
+
+
+def test_finalize_skips_document_set_when_already_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Idempotent: a request that already has a document_set_id must not create a
+    # second one (the duplicate-artifact bug a pod crash would otherwise cause).
+    order: list[str] = []
+    _wire_finalize(monkeypatch, order=order)
+    req = _finalize_request(document_set_id=999)
+    provision.finalize_onboarding(req, _FakeSession(order))  # type: ignore[arg-type]
+    assert "doc_set" not in order
+    assert order == ["rollback", "persona", "slack", "status:complete"]
+    assert req.document_set_id == 999  # unchanged
+
+
+def test_finalize_resumes_only_remaining_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Resume: doc set + persona already done -> only the Slack config is created.
+    order: list[str] = []
+    _wire_finalize(monkeypatch, order=order)
+    req = _finalize_request(document_set_id=999, persona_id=888)
+    provision.finalize_onboarding(req, _FakeSession(order))  # type: ignore[arg-type]
+    assert order == ["rollback", "slack", "status:complete"]
+    assert req.slack_bot_config_id == 303
+
+
+def test_finalize_recovers_after_crash_without_duplicating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Crash-safety: the first attempt creates doc set + persona (ids persisted)
+    # then dies at the Slack step. The retry must NOT recreate doc set / persona
+    # — it resumes at Slack and completes.
+    order1: list[str] = []
+    _wire_finalize(monkeypatch, order=order1, fail_on="slack")
+    req = _finalize_request()
+    with pytest.raises(RuntimeError):
+        provision.finalize_onboarding(req, _FakeSession(order1))  # type: ignore[arg-type]
+    # Checkpoints persisted before the crash:
+    assert req.document_set_id == 101
+    assert req.persona_id == 202
+    assert req.slack_bot_config_id is None
+    assert req.status != OnboardingStatus.COMPLETE.value
+
+    # Next finalizer tick (no injected failure): resumes at Slack only.
+    order2: list[str] = []
+    calls2 = _wire_finalize(monkeypatch, order=order2)
+    provision.finalize_onboarding(req, _FakeSession(order2))  # type: ignore[arg-type]
+    assert order2 == ["rollback", "slack", "status:complete"]
+    assert "doc_set" not in order2 and "persona" not in order2
+    assert req.slack_bot_config_id == 303
+    assert req.status == OnboardingStatus.COMPLETE.value
+    assert calls2["notified"] == 1
+
+
+def test_finalize_completes_even_if_notify_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A completion-notification failure must not fail finalize — the request is
+    # already COMPLETE and would otherwise be retried (and re-notified) forever.
+    order: list[str] = []
+    calls = _wire_finalize(monkeypatch, order=order, notify_raises=True)
+    req = _finalize_request()
+    provision.finalize_onboarding(req, _FakeSession(order))  # type: ignore[arg-type]
+    assert req.status == OnboardingStatus.COMPLETE.value
+    assert calls["notified"] == 1
+
+
+def test_finalizer_isolates_finalize_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If finalize_onboarding throws, the sweep must swallow it (rollback + log)
+    # so the request stays tracked for the next tick and other requests proceed.
+    req = _req(12, OnboardingStatus.INDEXING)
+    calls = _wire(
+        monkeypatch, indexing=[req], failed=[], state=lambda r: (True, [], False)
+    )
+
+    def _boom(r: object, db: object) -> None:
+        raise RuntimeError("finalize kaboom")
+
+    monkeypatch.setattr(provision, "finalize_onboarding", _boom)
+    db = SimpleNamespace(rollback=lambda: calls.setdefault("rolled_back", True))
+    # Must not raise.
+    provision.finalize_ready_onboarding_requests(db)  # type: ignore[arg-type]
+    assert calls.get("rolled_back") is True
 
 
 def test_per_request_error_is_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -190,7 +500,7 @@ def test_per_request_error_is_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
     def _state(r: object) -> tuple:
         if r.id == 7:  # type: ignore[attr-defined]
             raise RuntimeError("kaboom")
-        return (True, [])
+        return (True, [], False)
 
     calls = _wire(monkeypatch, indexing=[bad, good], failed=[], state=_state)
     db = SimpleNamespace(rollback=lambda: calls.setdefault("rolled_back", True))

--- a/backend/tests/unit/danswer/onboarding/test_finalizer.py
+++ b/backend/tests/unit/danswer/onboarding/test_finalizer.py
@@ -1,0 +1,199 @@
+"""Unit tests for the background onboarding finalizer state machine.
+
+Covers `_source_index_state` (reading per-source scrape status) and
+`finalize_ready_onboarding_requests` (finalize on success, flag failure once,
+recover a previously-FAILED request) — positive and negative paths."""
+from types import SimpleNamespace
+
+import pytest
+
+from danswer.db.enums import IndexingStatus
+from danswer.db.models import OnboardingStatus
+from danswer.onboarding import provision
+
+
+# --- _source_index_state ---------------------------------------------------
+
+
+class _Result:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object:
+        return self._value
+
+
+class _Session:
+    """Returns queued latest-attempt rows, one per execute() call (one per cc)."""
+
+    def __init__(self, attempts: list) -> None:
+        self._attempts = list(attempts)
+
+    def execute(self, *args: object, **kwargs: object) -> _Result:
+        return _Result(self._attempts.pop(0) if self._attempts else None)
+
+
+def _attempt(status: IndexingStatus, err: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(status=status, error_msg=err)
+
+
+def _patch_cc(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        provision,
+        "get_connector_credential_pair_from_id",
+        lambda cc_id, db: SimpleNamespace(
+            connector_id=cc_id, credential_id=cc_id, name=f"src-{cc_id}"
+        ),
+    )
+
+
+def test_state_all_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_cc(monkeypatch)
+    req = SimpleNamespace(cc_pair_ids=[10, 11])
+    sess = _Session(
+        [_attempt(IndexingStatus.SUCCESS), _attempt(IndexingStatus.SUCCESS)]
+    )
+    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    assert all_indexed is True
+    assert failures == []
+
+
+def test_state_one_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_cc(monkeypatch)
+    req = SimpleNamespace(cc_pair_ids=[10, 11])
+    sess = _Session(
+        [_attempt(IndexingStatus.SUCCESS), _attempt(IndexingStatus.FAILED, "boom")]
+    )
+    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    assert all_indexed is False
+    assert len(failures) == 1 and "boom" in failures[0]
+
+
+def test_state_in_progress_is_not_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_cc(monkeypatch)
+    req = SimpleNamespace(cc_pair_ids=[10, 11])
+    sess = _Session(
+        [_attempt(IndexingStatus.SUCCESS), _attempt(IndexingStatus.IN_PROGRESS)]
+    )
+    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    assert all_indexed is False  # still scraping
+    assert failures == []  # not a failure either
+
+
+def test_state_no_attempt_yet_is_not_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_cc(monkeypatch)
+    req = SimpleNamespace(cc_pair_ids=[10])
+    sess = _Session([None])  # no index attempt row yet
+    all_indexed, failures = provision._source_index_state(req, sess)  # type: ignore[arg-type]
+    assert all_indexed is False
+    assert failures == []
+
+
+def test_state_no_cc_pairs() -> None:
+    req = SimpleNamespace(cc_pair_ids=[])
+    assert provision._source_index_state(req, None) == (False, [])  # type: ignore[arg-type]
+
+
+# --- finalize_ready_onboarding_requests ------------------------------------
+
+
+def _wire(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    indexing: list,
+    failed: list,
+    state,  # callable(request) -> (all_indexed, failures)
+) -> dict:
+    """Patch the finalizer's collaborators and capture what it does."""
+    calls: dict = {"finalized": [], "failed_notified": [], "status": []}
+
+    def _list(db: object, status: OnboardingStatus) -> list:
+        return indexing if status == OnboardingStatus.INDEXING else failed
+
+    monkeypatch.setattr(provision, "list_onboarding_requests", _list)
+    monkeypatch.setattr(provision, "_source_index_state", lambda r, db: state(r))
+    monkeypatch.setattr(
+        provision, "finalize_onboarding", lambda r, db: calls["finalized"].append(r.id)
+    )
+    monkeypatch.setattr(
+        provision,
+        "notify_onboarding_failed",
+        lambda r, detail: calls["failed_notified"].append((r.id, detail)),
+    )
+
+    def _update(
+        db: object, r: object, status: OnboardingStatus, **kw: object
+    ) -> object:
+        r.status = status.value  # type: ignore[attr-defined]
+        calls["status"].append((r.id, status.value))  # type: ignore[attr-defined]
+        return r
+
+    monkeypatch.setattr(provision, "update_onboarding_status", _update)
+    return calls
+
+
+def _req(id_: int, status: OnboardingStatus) -> SimpleNamespace:
+    return SimpleNamespace(id=id_, status=status.value, cc_pair_ids=[1])
+
+
+def test_finalizes_when_all_indexed(monkeypatch: pytest.MonkeyPatch) -> None:
+    req = _req(1, OnboardingStatus.INDEXING)
+    calls = _wire(monkeypatch, indexing=[req], failed=[], state=lambda r: (True, []))
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert calls["finalized"] == [1]
+    assert calls["failed_notified"] == []
+
+
+def test_flags_failure_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    req = _req(2, OnboardingStatus.INDEXING)
+    calls = _wire(
+        monkeypatch, indexing=[req], failed=[], state=lambda r: (False, ["src-1: boom"])
+    )
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert (2, OnboardingStatus.FAILED.value) in calls["status"]
+    assert calls["failed_notified"] == [(2, "src-1: boom")]
+    assert calls["finalized"] == []
+
+
+def test_already_failed_not_renotified(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A FAILED request that is still failing must not spam notifications.
+    req = _req(3, OnboardingStatus.FAILED)
+    calls = _wire(
+        monkeypatch, indexing=[], failed=[req], state=lambda r: (False, ["still bad"])
+    )
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert calls["failed_notified"] == []
+    assert calls["finalized"] == []
+
+
+def test_recovers_previously_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A FAILED request whose sources now succeed is finalized — no restart needed.
+    req = _req(4, OnboardingStatus.FAILED)
+    calls = _wire(monkeypatch, indexing=[], failed=[req], state=lambda r: (True, []))
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert calls["finalized"] == [4]
+
+
+def test_still_indexing_does_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    req = _req(5, OnboardingStatus.INDEXING)
+    calls = _wire(monkeypatch, indexing=[req], failed=[], state=lambda r: (False, []))
+    provision.finalize_ready_onboarding_requests(None)  # type: ignore[arg-type]
+    assert calls["finalized"] == []
+    assert calls["failed_notified"] == []
+
+
+def test_per_request_error_is_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
+    # One request blowing up must not stop the others from being processed.
+    good = _req(6, OnboardingStatus.INDEXING)
+    bad = _req(7, OnboardingStatus.INDEXING)
+
+    def _state(r: object) -> tuple:
+        if r.id == 7:  # type: ignore[attr-defined]
+            raise RuntimeError("kaboom")
+        return (True, [])
+
+    calls = _wire(monkeypatch, indexing=[bad, good], failed=[], state=_state)
+    db = SimpleNamespace(rollback=lambda: calls.setdefault("rolled_back", True))
+    provision.finalize_ready_onboarding_requests(db)  # type: ignore[arg-type]
+    assert calls["finalized"] == [6]  # good one still finalized
+    assert calls.get("rolled_back") is True  # bad one rolled back

--- a/backend/tests/unit/danswer/onboarding/test_finalizer.py
+++ b/backend/tests/unit/danswer/onboarding/test_finalizer.py
@@ -5,6 +5,7 @@ in-progress flag) and `finalize_ready_onboarding_requests` (finalize on success,
 flag failure once, recover a previously-FAILED request, and flip a re-indexing
 FAILED request back to INDEXING) — positive and negative paths."""
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -128,7 +129,7 @@ def _wire(
     *,
     indexing: list,
     failed: list,
-    state,  # callable(request) -> (all_indexed, failures, in_progress)
+    state: Any,  # callable(request) -> (all_indexed, failures, in_progress)
 ) -> dict:
     """Patch the finalizer's collaborators and capture what it does."""
     calls: dict = {"finalized": [], "failed_notified": [], "status": []}
@@ -362,7 +363,7 @@ def _wire_finalize(
 
     def _status(db: object, req: object, status: object, **kw: object) -> object:
         req.status = status.value  # type: ignore[attr-defined]
-        order.append(f"status:{status.value}")
+        order.append(f"status:{status.value}")  # type: ignore[attr-defined]
         return req
 
     monkeypatch.setattr(provision, "update_onboarding_status", _status)

--- a/backend/tests/unit/danswer/onboarding/test_notify.py
+++ b/backend/tests/unit/danswer/onboarding/test_notify.py
@@ -171,7 +171,7 @@ def test_client_reply_skips_without_thread_ts(
 
     _patch_client(monkeypatch, _Client)
     monkeypatch.setattr(notify, "ONBOARDING_CLIENT_CHANNEL", "help-darwin")
-    notify.notify_client_complete(_req())  # _req has no help_thread_ts
+    notify.notify_client_complete(_req())  # type: ignore[arg-type]
     assert built["n"] == 0
 
 

--- a/backend/tests/unit/danswer/onboarding/test_notify.py
+++ b/backend/tests/unit/danswer/onboarding/test_notify.py
@@ -42,6 +42,31 @@ def test_notify_posts_message(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "jo@uipath.com" in text
     assert "Automation Suite" in text
     assert "help-automation-suite" in text
+    # Submitted notification links to the request's form so the admin can open,
+    # review and approve it directly.
+    assert "/admin/onboarding/7" in text
+
+
+def test_notify_complete_includes_status_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    class _Client:
+        def __init__(self, token: str) -> None:
+            pass
+
+        def chat_postMessage(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_NOTIFY_CHANNEL", "darwin-devs")
+    monkeypatch.setattr(notify, "WEB_DOMAIN", "https://darwin.example.com")
+    notify.notify_onboarding_complete(_req())  # type: ignore[arg-type]
+
+    text = captured["text"]
+    assert "is now live in #help-automation-suite" in text
+    assert "https://darwin.example.com/admin/onboarding" in text
 
 
 def test_notify_swallows_slack_errors(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/danswer/onboarding/test_notify.py
+++ b/backend/tests/unit/danswer/onboarding/test_notify.py
@@ -1,0 +1,71 @@
+"""Unit tests for onboarding Slack notifications (mocked — no network)."""
+from types import SimpleNamespace
+
+import pytest
+
+from danswer.onboarding import notify
+
+
+def _req() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=7,
+        requester_email="jo@uipath.com",
+        payload={
+            "team_name": "Automation Suite",
+            "channel": {"channel_name": "help-automation-suite"},
+            "sources": [{"type": "web", "label": "Docs (cloud)"}],
+        },
+    )
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, client_cls: type) -> None:
+    monkeypatch.setattr(notify, "WebClient", client_cls)
+    monkeypatch.setattr(notify, "fetch_tokens", lambda: SimpleNamespace(bot_token="x"))
+
+
+def test_notify_posts_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    class _Client:
+        def __init__(self, token: str) -> None:
+            pass
+
+        def chat_postMessage(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_NOTIFY_CHANNEL", "darwin-devs")
+    notify.notify_onboarding_submitted(_req())  # type: ignore[arg-type]
+
+    assert captured["channel"] == "darwin-devs"
+    text = captured["text"]
+    assert "jo@uipath.com" in text
+    assert "Automation Suite" in text
+    assert "help-automation-suite" in text
+
+
+def test_notify_swallows_slack_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Client:
+        def __init__(self, token: str) -> None:
+            pass
+
+        def chat_postMessage(self, **kwargs: object) -> None:
+            raise Exception("slack is down")
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_NOTIFY_CHANNEL", "darwin-devs")
+    # Must not raise — submission must never fail on a notification hiccup.
+    notify.notify_onboarding_submitted(_req())  # type: ignore[arg-type]
+
+
+def test_notify_noop_when_channel_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    created = {"n": 0}
+
+    class _Client:
+        def __init__(self, token: str) -> None:
+            created["n"] += 1
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_NOTIFY_CHANNEL", "")
+    notify.notify_onboarding_submitted(_req())  # type: ignore[arg-type]
+    assert created["n"] == 0  # no client built, nothing posted

--- a/backend/tests/unit/danswer/onboarding/test_notify.py
+++ b/backend/tests/unit/danswer/onboarding/test_notify.py
@@ -69,3 +69,15 @@ def test_notify_noop_when_channel_unset(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(notify, "ONBOARDING_NOTIFY_CHANNEL", "")
     notify.notify_onboarding_submitted(_req())  # type: ignore[arg-type]
     assert created["n"] == 0  # no client built, nothing posted
+
+
+def test_resolve_channel_accepts_id_name_or_link() -> None:
+    assert notify._resolve_channel("C07B2V8E99S") == "C07B2V8E99S"
+    assert notify._resolve_channel("darwin-devs") == "darwin-devs"
+    assert (
+        notify._resolve_channel(
+            "https://uipath.enterprise.slack.com/archives/C07B2V8E99S"
+        )
+        == "C07B2V8E99S"
+    )
+    assert notify._resolve_channel("  #ops  ") == "#ops"

--- a/backend/tests/unit/danswer/onboarding/test_notify.py
+++ b/backend/tests/unit/danswer/onboarding/test_notify.py
@@ -96,6 +96,107 @@ def test_notify_noop_when_channel_unset(monkeypatch: pytest.MonkeyPatch) -> None
     assert created["n"] == 0  # no client built, nothing posted
 
 
+# --- customer-facing thread ------------------------------------------------
+
+
+def test_client_submitted_returns_ts_mentions_and_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    class _Client:
+        def __init__(self, token: str) -> None:
+            pass
+
+        def conversations_join(self, **kwargs: object) -> None:
+            captured["joined"] = kwargs.get("channel")
+
+        def users_lookupByEmail(self, email: str) -> dict:
+            return {"user": {"id": "U999"}}
+
+        def chat_postMessage(self, **kwargs: object) -> dict:
+            captured.update(kwargs)
+            return {"ts": "111.222"}
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_CLIENT_CHANNEL", "help-darwin")
+    monkeypatch.setattr(notify, "WEB_DOMAIN", "https://darwin.example.com")
+
+    ts = notify.notify_client_submitted(_req())  # type: ignore[arg-type]
+    assert ts == "111.222"
+    assert captured["channel"] == "help-darwin"
+    assert "<@U999>" in captured["text"]  # requester @mentioned
+    assert "https://darwin.example.com/onboarding?view=requests" in captured["text"]
+    assert "thread_ts" not in captured  # root message, not a reply
+
+
+def test_client_submitted_mention_falls_back_to_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    class _Client:
+        def __init__(self, token: str) -> None:
+            pass
+
+        def conversations_join(self, **kwargs: object) -> None:
+            pass
+
+        def users_lookupByEmail(self, email: str) -> dict:
+            raise Exception("users_not_found")
+
+        def chat_postMessage(self, **kwargs: object) -> dict:
+            captured.update(kwargs)
+            return {"ts": "1"}
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_CLIENT_CHANNEL", "help-darwin")
+    notify.notify_client_submitted(_req())  # type: ignore[arg-type]
+    assert "jo@uipath.com" in captured["text"]  # plain-text fallback
+
+
+def test_client_reply_skips_without_thread_ts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No stored thread ts -> must NOT post anything (never a top-level message).
+    built = {"n": 0}
+
+    class _Client:
+        def __init__(self, token: str) -> None:
+            built["n"] += 1
+
+        def chat_postMessage(self, **kwargs: object) -> dict:
+            built["n"] += 100
+            return {"ts": "x"}
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_CLIENT_CHANNEL", "help-darwin")
+    notify.notify_client_complete(_req())  # _req has no help_thread_ts
+    assert built["n"] == 0
+
+
+def test_client_reply_threads_when_ts_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    class _Client:
+        def __init__(self, token: str) -> None:
+            pass
+
+        def chat_postMessage(self, **kwargs: object) -> dict:
+            captured.update(kwargs)
+            return {"ts": "y"}
+
+    _patch_client(monkeypatch, _Client)
+    monkeypatch.setattr(notify, "ONBOARDING_CLIENT_CHANNEL", "help-darwin")
+    req = _req()
+    req.help_thread_ts = "111.222"
+    notify.notify_client_complete(req)  # type: ignore[arg-type]
+    assert captured["thread_ts"] == "111.222"  # posted as a reply
+    assert "live in #help-automation-suite" in captured["text"]
+
+
 def test_resolve_channel_accepts_id_name_or_link() -> None:
     assert notify._resolve_channel("C07B2V8E99S") == "C07B2V8E99S"
     assert notify._resolve_channel("darwin-devs") == "darwin-devs"

--- a/backend/tests/unit/danswer/onboarding/test_provision.py
+++ b/backend/tests/unit/danswer/onboarding/test_provision.py
@@ -1,0 +1,115 @@
+"""Unit tests for the onboarding provisioning builders (pure logic — no DB/IO)."""
+from danswer.configs.constants import DocumentSource
+from danswer.onboarding.provision import _build_channel_config
+from danswer.onboarding.provision import _build_connector_base
+from danswer.onboarding.provision import _parse_github_repo
+from danswer.onboarding.provision import _source_type_value
+
+
+def test_web_docs_uipath_enables_all_versions() -> None:
+    cb = _build_connector_base(
+        {
+            "type": "web",
+            "value": "https://docs.uipath.com/orchestrator/automation-cloud/latest",
+        },
+        db_session=None,  # type: ignore[arg-type]  # web path doesn't touch the db
+    )
+    assert cb.source == DocumentSource.WEB
+    cfg = cb.connector_specific_config
+    assert cfg["base_url"].startswith("https://docs.uipath.com/orchestrator")
+    assert cfg["uipath_latest_versions"] is True
+    assert cfg["web_connector_type"] == "recursive"
+
+
+def test_web_non_docs_does_not_enable_all_versions() -> None:
+    cb = _build_connector_base(
+        {"type": "web", "value": "https://example.com/help"},
+        db_session=None,  # type: ignore[arg-type]
+    )
+    assert "uipath_latest_versions" not in cb.connector_specific_config
+
+
+def test_confluence_source_config() -> None:
+    url = "https://uipath.atlassian.net/wiki/spaces/DEV/overview"
+    cb = _build_connector_base(
+        {"type": "confluence", "value": url}, db_session=None  # type: ignore[arg-type]
+    )
+    assert cb.source == DocumentSource.CONFLUENCE
+    assert cb.connector_specific_config["wiki_page_url"] == url
+
+
+def test_github_source_config_parses_owner_repo() -> None:
+    cb = _build_connector_base(
+        {"type": "github", "value": "https://github.com/UiPath/testsfagents"},
+        db_session=None,  # type: ignore[arg-type]
+    )
+    assert cb.source == DocumentSource.GITHUB
+    assert cb.connector_specific_config["repo_owner"] == "UiPath"
+    assert cb.connector_specific_config["repo_name"] == "testsfagents"
+
+
+def test_parse_github_repo() -> None:
+    assert _parse_github_repo("https://github.com/UiPath/danswer") == (
+        "UiPath",
+        "danswer",
+    )
+
+
+def test_source_type_value_mapping() -> None:
+    assert _source_type_value("web") == DocumentSource.WEB.value
+    assert _source_type_value("confluence") == DocumentSource.CONFLUENCE.value
+    assert _source_type_value("github") == DocumentSource.GITHUB.value
+    assert _source_type_value("slack") == DocumentSource.SLACK.value
+
+
+def _payload(**over: object) -> dict:
+    base = {
+        "team_name": "Team X",
+        "channel": {"channel_id": "C1", "channel_name": "help-x"},
+        "respond_tag_only": True,
+        "sme": {"enabled": False, "group_name": ""},
+        "oncall": {"enabled": False, "schedule": ""},
+        "jira": {"enabled": False},
+    }
+    base.update(over)
+    return base
+
+
+def test_channel_config_basic() -> None:
+    cfg = _build_channel_config(_payload(), prioritized_sources=["confluence", "web"])
+    assert cfg["channel_names"] == ["help-x"]
+    assert cfg["respond_tag_only"] is True
+    assert cfg["prioritized_sources"] == ["confluence", "web"]
+    assert "enable_sme_validation" not in cfg
+    assert "opsgenie_schedule" not in cfg
+    assert "jira_config" not in cfg
+
+
+def test_channel_config_all_options() -> None:
+    cfg = _build_channel_config(
+        _payload(
+            sme={"enabled": True, "group_name": "as-smes"},
+            oncall={"enabled": True, "schedule": "AS-OnCall"},
+            jira={
+                "enabled": True,
+                "project_key": "AS",
+                "issue_type": "Bug",
+                "component": "core",
+            },
+        ),
+        prioritized_sources=["web"],
+    )
+    assert cfg["enable_sme_validation"] is True
+    assert cfg["sme_group_name"] == "as-smes"
+    assert cfg["opsgenie_schedule"] == "AS-OnCall"
+    assert cfg["jira_config"]["enable_jira_integration"] is True
+    assert cfg["jira_config"]["project_key"] == "AS"
+
+
+def test_channel_config_oncall_enabled_but_no_schedule_omitted() -> None:
+    # Enabling on-call without a schedule shouldn't write an empty opsgenie value.
+    cfg = _build_channel_config(
+        _payload(oncall={"enabled": True, "schedule": ""}),
+        prioritized_sources=[],
+    )
+    assert "opsgenie_schedule" not in cfg

--- a/backend/tests/unit/danswer/onboarding/test_provision.py
+++ b/backend/tests/unit/danswer/onboarding/test_provision.py
@@ -1,12 +1,27 @@
 """Unit tests for the onboarding provisioning builders (pure logic — no DB/IO)."""
+import pytest
+
 from danswer.configs.constants import DocumentSource
+from danswer.onboarding import provision
 from danswer.onboarding.provision import _build_channel_config
 from danswer.onboarding.provision import _build_connector_base
 from danswer.onboarding.provision import _parse_github_repo
 from danswer.onboarding.provision import _source_type_value
 
 
-def test_web_docs_uipath_enables_all_versions() -> None:
+def _allow_public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the web SSRF guard see any host as a public address, offline."""
+    monkeypatch.setattr(
+        provision.socket,
+        "getaddrinfo",
+        lambda host, port: [(2, 1, 6, "", ("93.184.216.34", 0))],
+    )
+
+
+def test_web_docs_uipath_enables_all_versions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_public_dns(monkeypatch)
     cb = _build_connector_base(
         {
             "type": "web",
@@ -21,7 +36,10 @@ def test_web_docs_uipath_enables_all_versions() -> None:
     assert cfg["web_connector_type"] == "recursive"
 
 
-def test_web_non_docs_does_not_enable_all_versions() -> None:
+def test_web_non_docs_does_not_enable_all_versions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_public_dns(monkeypatch)
     cb = _build_connector_base(
         {"type": "web", "value": "https://example.com/help"},
         db_session=None,  # type: ignore[arg-type]
@@ -29,13 +47,59 @@ def test_web_non_docs_does_not_enable_all_versions() -> None:
     assert "uipath_latest_versions" not in cb.connector_specific_config
 
 
-def test_confluence_source_config() -> None:
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/internal",  # loopback
+        "http://10.0.0.5/admin",  # RFC1918 private
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata (link-local)
+        "file:///etc/passwd",  # non-http scheme
+    ],
+)
+def test_web_rejects_internal_targets(url: str) -> None:
+    # IP-literal / bad-scheme rejects need no DNS, so no monkeypatch required.
+    with pytest.raises(ValueError):
+        _build_connector_base(
+            {"type": "web", "value": url}, db_session=None  # type: ignore[arg-type]
+        )
+
+
+def test_confluence_source_config(monkeypatch: pytest.MonkeyPatch) -> None:
     url = "https://uipath.atlassian.net/wiki/spaces/DEV/overview"
+    monkeypatch.setattr(
+        provision, "_allowed_confluence_hosts", lambda db: {"uipath.atlassian.net"}
+    )
     cb = _build_connector_base(
         {"type": "confluence", "value": url}, db_session=None  # type: ignore[arg-type]
     )
     assert cb.source == DocumentSource.CONFLUENCE
     assert cb.connector_specific_config["wiki_page_url"] == url
+
+
+def test_confluence_rejects_unknown_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        provision, "_allowed_confluence_hosts", lambda db: {"uipath.atlassian.net"}
+    )
+    with pytest.raises(ValueError):
+        _build_connector_base(
+            {"type": "confluence", "value": "https://evil.example.com/wiki/spaces/X"},
+            db_session=None,  # type: ignore[arg-type]
+        )
+
+
+def test_confluence_rejects_when_no_known_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No existing Confluence connector to vet against -> fail closed.
+    monkeypatch.setattr(provision, "_allowed_confluence_hosts", lambda db: set())
+    with pytest.raises(ValueError):
+        _build_connector_base(
+            {
+                "type": "confluence",
+                "value": "https://uipath.atlassian.net/wiki/spaces/X",
+            },
+            db_session=None,  # type: ignore[arg-type]
+        )
 
 
 def test_github_source_config_parses_owner_repo() -> None:
@@ -46,6 +110,51 @@ def test_github_source_config_parses_owner_repo() -> None:
     assert cb.source == DocumentSource.GITHUB
     assert cb.connector_specific_config["repo_owner"] == "UiPath"
     assert cb.connector_specific_config["repo_name"] == "testsfagents"
+
+
+def test_github_rejects_non_github_host() -> None:
+    with pytest.raises(ValueError):
+        _build_connector_base(
+            {"type": "github", "value": "https://evil.example.com/UiPath/x"},
+            db_session=None,  # type: ignore[arg-type]
+        )
+
+
+# --- provision-time credential-access preflight ---------------------------
+
+from danswer.onboarding.provision import _assert_source_accessible  # noqa: E402
+from danswer.onboarding.validation import ValidationResult  # noqa: E402
+
+
+def test_preflight_web_is_noop() -> None:
+    # Web is public (no credential) — preflight must not raise.
+    _assert_source_accessible(
+        {"type": "web", "value": "https://example.com"}, db_session=None  # type: ignore[arg-type]
+    )
+
+
+def test_preflight_raises_when_inaccessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        provision,
+        "validate_github_repo",
+        lambda value, db: ValidationResult(valid=False, message="no access"),
+    )
+    with pytest.raises(ValueError, match="not accessible"):
+        _assert_source_accessible(
+            {"type": "github", "value": "https://github.com/UiPath/x"},
+            db_session=None,  # type: ignore[arg-type]
+        )
+
+
+def test_preflight_passes_when_accessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        provision,
+        "validate_slack_channel",
+        lambda value: ValidationResult(valid=True, message="#ok"),
+    )
+    _assert_source_accessible(
+        {"type": "slack", "value": "help-x"}, db_session=None  # type: ignore[arg-type]
+    )
 
 
 def test_parse_github_repo() -> None:

--- a/backend/tests/unit/danswer/onboarding/test_provision.py
+++ b/backend/tests/unit/danswer/onboarding/test_provision.py
@@ -222,3 +222,102 @@ def test_channel_config_oncall_enabled_but_no_schedule_omitted() -> None:
         prioritized_sources=[],
     )
     assert "opsgenie_schedule" not in cfg
+
+
+# --- per-source refresh cadence -------------------------------------------
+
+from danswer.onboarding.provision import _MONTHLY_REFRESH_FREQ  # noqa: E402
+from danswer.onboarding.provision import DEFAULT_REFRESH_FREQ  # noqa: E402
+from danswer.onboarding.provision import _dedup_confluence_sources  # noqa: E402
+from danswer.onboarding.provision import _prioritized_sources  # noqa: E402
+
+
+def test_web_source_refresh_is_monthly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_public_dns(monkeypatch)
+    cb = _build_connector_base(
+        {"type": "web", "value": "https://docs.uipath.com/x/latest"},
+        db_session=None,  # type: ignore[arg-type]
+    )
+    assert cb.refresh_freq == _MONTHLY_REFRESH_FREQ
+
+
+def test_confluence_source_refresh_is_daily(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        provision, "_allowed_confluence_hosts", lambda db: {"x.atlassian.net"}
+    )
+    cb = _build_connector_base(
+        {"type": "confluence", "value": "https://x.atlassian.net/wiki/spaces/DEV/x"},
+        db_session=None,  # type: ignore[arg-type]
+    )
+    assert cb.refresh_freq == DEFAULT_REFRESH_FREQ
+
+
+# --- prioritized sources ---------------------------------------------------
+
+
+def test_prioritized_sources_distinct_in_order() -> None:
+    sources = [
+        {"type": "web", "value": "a"},
+        {"type": "slack", "value": "b"},
+        {"type": "web", "value": "c"},  # duplicate type
+    ]
+    assert _prioritized_sources(sources) == ["web", "slack"]
+
+
+# --- confluence parent/child dedup ----------------------------------------
+
+
+def test_dedup_passthrough_when_fewer_than_two_confluence() -> None:
+    sources = [
+        {"type": "confluence", "value": "https://x.atlassian.net/wiki/spaces/DEV/x"},
+        {"type": "web", "value": "https://docs.example.com"},
+    ]
+    assert _dedup_confluence_sources(sources, db_session=None) == sources  # type: ignore[arg-type]
+
+
+def test_dedup_space_supersedes_page() -> None:
+    space = {
+        "type": "confluence",
+        "value": "https://x.atlassian.net/wiki/spaces/DEV/overview",
+    }
+    page = {
+        "type": "confluence",
+        "value": "https://x.atlassian.net/wiki/spaces/DEV/pages/123/Title",
+    }
+    out = _dedup_confluence_sources([space, page], db_session=None)  # type: ignore[arg-type]
+    assert out == [space]  # the page (child of the space) is dropped
+
+
+def test_dedup_parent_page_supersedes_child(monkeypatch: pytest.MonkeyPatch) -> None:
+    parent = {
+        "type": "confluence",
+        "value": "https://x.atlassian.net/wiki/spaces/DEV/pages/100/Parent",
+    }
+    child = {
+        "type": "confluence",
+        "value": "https://x.atlassian.net/wiki/spaces/DEV/pages/200/Child",
+    }
+    # 200's ancestor is 100 (also provided) -> child dropped.
+    monkeypatch.setattr(
+        provision,
+        "confluence_page_ancestors",
+        lambda ids, db: {"100": [], "200": ["100"]},
+    )
+    out = _dedup_confluence_sources([parent, child], db_session=None)  # type: ignore[arg-type]
+    assert out == [parent]
+
+
+def test_dedup_keeps_unrelated_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    a = {
+        "type": "confluence",
+        "value": "https://x.atlassian.net/wiki/spaces/DEV/pages/100/A",
+    }
+    b = {
+        "type": "confluence",
+        "value": "https://x.atlassian.net/wiki/spaces/DEV/pages/300/B",
+    }
+    monkeypatch.setattr(
+        provision, "confluence_page_ancestors", lambda ids, db: {"100": [], "300": []}
+    )
+    out = _dedup_confluence_sources([a, b], db_session=None)  # type: ignore[arg-type]
+    assert out == [a, b]

--- a/backend/tests/unit/danswer/onboarding/test_provision.py
+++ b/backend/tests/unit/danswer/onboarding/test_provision.py
@@ -33,6 +33,7 @@ def test_web_docs_uipath_enables_all_versions(
     cfg = cb.connector_specific_config
     assert cfg["base_url"].startswith("https://docs.uipath.com/orchestrator")
     assert cfg["uipath_latest_versions"] is True
+    assert cfg["max_versions"] == 3  # latest 3 versions
     assert cfg["web_connector_type"] == "recursive"
 
 

--- a/backend/tests/unit/danswer/onboarding/test_provision.py
+++ b/backend/tests/unit/danswer/onboarding/test_provision.py
@@ -322,3 +322,117 @@ def test_dedup_keeps_unrelated_pages(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     out = _dedup_confluence_sources([a, b], db_session=None)  # type: ignore[arg-type]
     assert out == [a, b]
+
+
+# --- provision_onboarding: cc_pair_ids records real cc_pair ids ------------
+
+from types import SimpleNamespace  # noqa: E402
+
+from danswer.db.models import OnboardingStatus  # noqa: E402
+from danswer.onboarding.provision import provision_onboarding  # noqa: E402
+
+
+def test_provision_records_cc_pair_ids_not_connector_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: in this fork add_credential_to_connector returns
+    data=connector_id (not the cc_pair id). provision_onboarding must store the
+    real cc_pair ids on the request — otherwise the finalizer/status track the
+    wrong pairs (the bug that surfaced an unrelated '[local-copy] jira' and
+    dropped a real source). We simulate connector_id != cc_pair_id and assert the
+    request gets the cc_pair ids."""
+    # Each created connector gets an incrementing id (1, 2, ...).
+    connector_ids = iter(range(1, 100))
+    captured: dict = {}
+
+    monkeypatch.setattr(provision, "update_onboarding_status", lambda *a, **k: None)
+    monkeypatch.setattr(
+        provision, "get_current_db_embedding_model", lambda db: SimpleNamespace(id=1)
+    )
+    monkeypatch.setattr(
+        provision, "_dedup_confluence_sources", lambda sources, db: sources
+    )
+    monkeypatch.setattr(provision, "_assert_source_accessible", lambda s, db: None)
+    monkeypatch.setattr(provision, "_build_connector_base", lambda s, db: s)
+    monkeypatch.setattr(
+        provision,
+        "create_connector",
+        lambda base, db: SimpleNamespace(id=next(connector_ids)),
+    )
+    monkeypatch.setattr(provision, "_credential_id_for_source", lambda stype, db: 500)
+    # The fork's real return shape: .data is the CONNECTOR id.
+    monkeypatch.setattr(
+        provision,
+        "add_credential_to_connector",
+        lambda **kw: SimpleNamespace(data=kw["connector_id"]),
+    )
+    # The real cc_pair id is deliberately different (connector_id + 1000).
+    monkeypatch.setattr(
+        provision,
+        "get_connector_credential_pair",
+        lambda connector_id, credential_id, db: SimpleNamespace(id=connector_id + 1000),
+    )
+    monkeypatch.setattr(
+        provision,
+        "set_provisioned_ids",
+        lambda db, req, cc_pair_ids: captured.__setitem__("cc_pair_ids", cc_pair_ids),
+    )
+    monkeypatch.setattr(provision, "create_index_attempt", lambda **k: 0)
+
+    request = SimpleNamespace(
+        id=1,
+        payload={
+            "team_name": "T",
+            "sources": [
+                {"type": "web", "value": "https://a", "label": "A"},
+                {"type": "slack", "value": "chan", "label": "B"},
+            ],
+        },
+    )
+    provision_onboarding(request, SimpleNamespace(id=42), None)  # type: ignore[arg-type]
+
+    # connectors were 1 and 2; real cc_pair ids are 1001 and 1002 — NOT [1, 2].
+    assert captured["cc_pair_ids"] == [1001, 1002]
+
+
+def test_provision_marks_failed_when_cc_pair_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the freshly-created pair can't be found, provisioning fails loudly
+    (marks FAILED + raises) rather than silently recording a bad id."""
+    statuses: list = []
+    monkeypatch.setattr(
+        provision,
+        "update_onboarding_status",
+        lambda db, req, status, **kw: statuses.append(status),
+    )
+    monkeypatch.setattr(
+        provision, "get_current_db_embedding_model", lambda db: SimpleNamespace(id=1)
+    )
+    monkeypatch.setattr(
+        provision, "_dedup_confluence_sources", lambda sources, db: sources
+    )
+    monkeypatch.setattr(provision, "_assert_source_accessible", lambda s, db: None)
+    monkeypatch.setattr(provision, "_build_connector_base", lambda s, db: s)
+    monkeypatch.setattr(
+        provision, "create_connector", lambda base, db: SimpleNamespace(id=7)
+    )
+    monkeypatch.setattr(provision, "_credential_id_for_source", lambda stype, db: 500)
+    monkeypatch.setattr(
+        provision, "add_credential_to_connector", lambda **kw: SimpleNamespace(data=7)
+    )
+    monkeypatch.setattr(
+        provision, "get_connector_credential_pair", lambda c, cr, db: None
+    )
+    monkeypatch.setattr(provision, "set_provisioned_ids", lambda *a, **k: None)
+
+    request = SimpleNamespace(
+        id=1,
+        payload={
+            "team_name": "T",
+            "sources": [{"type": "web", "value": "https://a", "label": "A"}],
+        },
+    )
+    with pytest.raises(ValueError):
+        provision_onboarding(request, SimpleNamespace(id=42), None)  # type: ignore[arg-type]
+    assert OnboardingStatus.FAILED in statuses

--- a/backend/tests/unit/danswer/onboarding/test_validation.py
+++ b/backend/tests/unit/danswer/onboarding/test_validation.py
@@ -2,7 +2,33 @@
 
 Slack/Confluence validators hit live APIs and are covered by manual/integration
 checks, not here."""
+import pytest
+
 from danswer.onboarding.validation import validate_docs_url
+from danswer.onboarding.validation import validate_github_repo
+
+
+class _Cred:
+    def __init__(self, cj: dict) -> None:
+        self.credential_json = cj
+
+
+class _Scalars:
+    def __init__(self, creds: list) -> None:
+        self._creds = creds
+
+    def scalars(self):  # type: ignore[no-untyped-def]
+        return iter(self._creds)
+
+
+class _FakeDb:
+    """Minimal Session stand-in for `_first_github_token`'s single query."""
+
+    def __init__(self, creds: list) -> None:
+        self._creds = creds
+
+    def execute(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return _Scalars(self._creds)
 
 
 def test_docs_url_valid_root_normalizes() -> None:
@@ -29,3 +55,67 @@ def test_docs_url_requires_product_path() -> None:
 
 def test_docs_url_empty() -> None:
     assert not validate_docs_url("").valid
+
+
+# --- validate_github_repo -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",  # empty
+        "https://gitlab.com/UiPath/x",  # wrong host
+        "https://evil.example.com/UiPath/x",  # non-github host
+        "https://github.com/UiPath",  # missing repo segment
+    ],
+)
+def test_github_repo_rejects_bad_input(url: str) -> None:
+    # These all return before touching the DB, so db_session can be None.
+    assert not validate_github_repo(url, db_session=None).valid  # type: ignore[arg-type]
+
+
+def test_github_repo_no_credential_is_unverified() -> None:
+    # No GitHub token on file -> valid but explicitly "unverified".
+    r = validate_github_repo("https://github.com/UiPath/danswer", _FakeDb([]))  # type: ignore[arg-type]
+    assert r.valid
+    assert "unverified" in r.message.lower()
+    assert r.resolved == {"repo_owner": "UiPath", "repo_name": "danswer"}
+
+
+def test_github_repo_accessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    import github as github_mod
+
+    class _OkGithub:
+        def __init__(self, token: str, base_url: str | None = None) -> None:
+            pass
+
+        def get_repo(self, full_name: str) -> object:
+            return object()
+
+    monkeypatch.setattr(github_mod, "Github", _OkGithub)
+    db = _FakeDb([_Cred({"github_access_token": "ghp_fake"})])
+    r = validate_github_repo("https://github.com/UiPath/danswer.git", db)  # type: ignore[arg-type]
+    assert r.valid
+    assert r.message == "UiPath/danswer"  # .git suffix stripped
+
+
+def test_github_repo_inaccessible_reports_generic_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import github as github_mod
+
+    class _DenyGithub:
+        def __init__(self, token: str, base_url: str | None = None) -> None:
+            pass
+
+        def get_repo(self, full_name: str) -> object:
+            # Message intentionally contains a token-like string to prove it is
+            # NOT propagated into the ValidationResult.
+            raise Exception("404 {'token': 'ghp_should_not_leak'}")
+
+    monkeypatch.setattr(github_mod, "Github", _DenyGithub)
+    db = _FakeDb([_Cred({"github_access_token": "ghp_fake"})])
+    r = validate_github_repo("https://github.com/UiPath/secret-repo", db)  # type: ignore[arg-type]
+    assert not r.valid
+    assert "not found or the GitHub app lacks access" in r.message
+    assert "ghp_" not in r.message  # no token / raw payload leakage

--- a/backend/tests/unit/danswer/onboarding/test_validation.py
+++ b/backend/tests/unit/danswer/onboarding/test_validation.py
@@ -1,0 +1,31 @@
+"""Unit tests for onboarding docs-URL validation (pure — no network).
+
+Slack/Confluence validators hit live APIs and are covered by manual/integration
+checks, not here."""
+from danswer.onboarding.validation import validate_docs_url
+
+
+def test_docs_url_valid_root_normalizes() -> None:
+    r = validate_docs_url(
+        "https://docs.uipath.com/orchestrator/automation-cloud/latest/user-guide/x"
+    )
+    assert r.valid
+    # Normalized to the product root (version/'latest' segment stripped).
+    assert (
+        r.resolved["root_url"]
+        == "https://docs.uipath.com/orchestrator/automation-cloud"
+    )
+
+
+def test_docs_url_rejects_non_docs_domain() -> None:
+    r = validate_docs_url("https://example.com/foo")
+    assert not r.valid
+
+
+def test_docs_url_requires_product_path() -> None:
+    r = validate_docs_url("https://docs.uipath.com/")
+    assert not r.valid
+
+
+def test_docs_url_empty() -> None:
+    assert not validate_docs_url("").valid

--- a/backend/tests/unit/danswer/onboarding/test_validation.py
+++ b/backend/tests/unit/danswer/onboarding/test_validation.py
@@ -187,3 +187,188 @@ def test_jira_filter_invalid_reports_generic_error(
     assert not r.valid
     assert "Invalid Jira filter" in r.message
     assert "token=" not in r.message  # no payload/token leakage
+
+
+# --- validate_slack_channel (mocked bot client) ---------------------------
+from slack_sdk.errors import SlackApiError  # noqa: E402
+
+from danswer.onboarding.validation import validate_slack_channel  # noqa: E402
+from danswer.onboarding.validation import validate_slack_group  # noqa: E402
+from danswer.onboarding.validation import validate_confluence_url  # noqa: E402
+
+
+class _SlackClient:
+    """Fake WebClient covering conversations_info + users_conversations paging."""
+
+    def __init__(
+        self,
+        info: dict | None = None,
+        info_error: str | None = None,
+        member_channels: list | None = None,
+    ):
+        self._info = info
+        self._info_error = info_error
+        self._member = member_channels or []
+
+    def conversations_info(self, channel: str) -> dict:
+        if self._info_error:
+            raise SlackApiError(self._info_error, {"error": self._info_error})
+        return {"channel": self._info}
+
+    def users_conversations(
+        self, limit: int = 1000, cursor: str | None = None, **kw: object
+    ) -> dict:
+        return {"channels": self._member, "response_metadata": {"next_cursor": ""}}
+
+
+def _patch_bot(monkeypatch: pytest.MonkeyPatch, client: object) -> None:
+    monkeypatch.setattr(validation, "_bot_client", lambda: client)
+
+
+def test_slack_channel_empty() -> None:
+    assert not validate_slack_channel("").valid
+
+
+def test_slack_channel_from_link(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_bot(monkeypatch, _SlackClient(info={"id": "C0ABC123", "name": "help-team"}))
+    r = validate_slack_channel(
+        "https://uipath-product.slack.com/archives/C0ABC123/p1712"
+    )
+    assert r.valid
+    assert r.resolved["channel_id"] == "C0ABC123"
+    assert r.resolved["channel_name"] == "help-team"
+
+
+def test_slack_channel_from_mention(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_bot(monkeypatch, _SlackClient(info={"id": "C0ABC123", "name": "help-team"}))
+    assert validate_slack_channel("<#C0ABC123|help-team>").valid
+
+
+def test_slack_channel_bad_id_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_bot(monkeypatch, _SlackClient(info_error="channel_not_found"))
+    r = validate_slack_channel("C0DEADBEEF")
+    assert not r.valid
+    assert "not found" in r.message.lower()
+
+
+def test_slack_channel_bare_name_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_bot(
+        monkeypatch,
+        _SlackClient(member_channels=[{"id": "C1", "name": "help-team"}]),
+    )
+    r = validate_slack_channel("help-team")
+    assert r.valid
+    assert "already in this channel" in r.message
+    assert r.resolved["channel_id"] == "C1"
+
+
+def test_slack_channel_bare_name_not_member_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Not in the bot's channels yet -> still accepted (bot added during onboarding).
+    _patch_bot(monkeypatch, _SlackClient(member_channels=[]))
+    r = validate_slack_channel("brand-new-channel")
+    assert r.valid
+    assert "will be added" in r.message
+    assert r.resolved["channel_name"] == "brand-new-channel"
+
+
+# --- validate_slack_group (comma-separated handles) -----------------------
+
+
+def test_slack_group_empty() -> None:
+    assert not validate_slack_group("").valid
+
+
+def test_slack_group_all_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_bot(monkeypatch, object())
+    monkeypatch.setattr(
+        validation,
+        "fetch_groupids_from_names",
+        lambda handles, client: (["G1", "G2"], []),
+    )
+    r = validate_slack_group("@as-dri, @sre-dri")
+    assert r.valid
+    assert r.message == "@as-dri, @sre-dri"
+
+
+def test_slack_group_some_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_bot(monkeypatch, object())
+    monkeypatch.setattr(
+        validation,
+        "fetch_groupids_from_names",
+        lambda handles, client: (["G1"], ["sre-dri"]),
+    )
+    r = validate_slack_group("@as-dri, @sre-dri")
+    assert not r.valid
+    assert "sre-dri" in r.message
+
+
+# --- validate_confluence_url (mocked host allowlist + client) -------------
+
+
+def test_confluence_url_bad_host_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        validation, "_allowed_confluence_hosts", lambda db: {"uipath.atlassian.net"}
+    )
+    r = validate_confluence_url("https://evil.atlassian.net/wiki/spaces/X", None)  # type: ignore[arg-type]
+    assert not r.valid
+    assert "host not allowed" in r.message.lower()
+
+
+def test_confluence_url_unverified_without_creds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(validation, "_allowed_confluence_hosts", lambda db: set())
+    monkeypatch.setattr(validation, "_first_confluence_credential", lambda db: None)
+    r = validate_confluence_url("https://uipath.atlassian.net/wiki/spaces/DEV/x", None)  # type: ignore[arg-type]
+    assert r.valid
+    assert "unverified" in r.message.lower()
+
+
+def test_confluence_url_space_accessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    import atlassian as atlassian_mod
+
+    class _OkConfluence:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def get_space(self, space: str) -> dict:
+            return {"key": space}
+
+    monkeypatch.setattr(
+        validation, "_allowed_confluence_hosts", lambda db: {"uipath.atlassian.net"}
+    )
+    monkeypatch.setattr(
+        validation,
+        "_first_confluence_credential",
+        lambda db: {"confluence_username": "u", "confluence_access_token": "t"},
+    )
+    monkeypatch.setattr(atlassian_mod, "Confluence", _OkConfluence)
+    r = validate_confluence_url("https://uipath.atlassian.net/wiki/spaces/DEV/x", None)  # type: ignore[arg-type]
+    assert r.valid
+    assert r.resolved["space"] == "DEV"
+
+
+def test_confluence_url_space_inaccessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    import atlassian as atlassian_mod
+
+    class _DenyConfluence:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def get_space(self, space: str) -> dict:
+            raise Exception("403 forbidden token=secret")
+
+    monkeypatch.setattr(
+        validation, "_allowed_confluence_hosts", lambda db: {"uipath.atlassian.net"}
+    )
+    monkeypatch.setattr(
+        validation,
+        "_first_confluence_credential",
+        lambda db: {"confluence_username": "u", "confluence_access_token": "t"},
+    )
+    monkeypatch.setattr(atlassian_mod, "Confluence", _DenyConfluence)
+    r = validate_confluence_url("https://uipath.atlassian.net/wiki/spaces/DEV/x", None)  # type: ignore[arg-type]
+    assert not r.valid
+    assert "secret" not in r.message  # no token/exception leakage

--- a/backend/tests/unit/danswer/onboarding/test_validation.py
+++ b/backend/tests/unit/danswer/onboarding/test_validation.py
@@ -397,6 +397,64 @@ def test_confluence_url_space_accessible(monkeypatch: pytest.MonkeyPatch) -> Non
     r = validate_confluence_url("https://uipath.atlassian.net/wiki/spaces/DEV/x", None)  # type: ignore[arg-type]
     assert r.valid
     assert r.resolved["space"] == "DEV"
+    assert "whole" in r.message and "space" in r.message  # space url -> whole space
+
+
+def test_confluence_url_page_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    import atlassian as atlassian_mod
+
+    class _OkConfluence:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def get_page_by_id(self, page_id: str) -> dict:
+            return {"id": page_id}
+
+    monkeypatch.setattr(
+        validation, "_allowed_confluence_hosts", lambda db: {"uipath.atlassian.net"}
+    )
+    monkeypatch.setattr(
+        validation,
+        "_first_confluence_credential",
+        lambda db: {"confluence_username": "u", "confluence_access_token": "t"},
+    )
+    monkeypatch.setattr(atlassian_mod, "Confluence", _OkConfluence)
+    r = validate_confluence_url(
+        "https://uipath.atlassian.net/wiki/spaces/DEV/pages/88998707616/Pro+Dev",
+        None,  # type: ignore[arg-type]
+    )
+    assert r.valid
+    # page url -> page + children, NOT the whole space
+    assert "child pages" in r.message
+    assert "whole" not in r.message
+    assert r.resolved["page_id"] == "88998707616"
+
+
+def test_confluence_url_page_inaccessible(monkeypatch: pytest.MonkeyPatch) -> None:
+    import atlassian as atlassian_mod
+
+    class _DenyConfluence:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def get_page_by_id(self, page_id: str) -> dict:
+            raise Exception("403 forbidden token=secret")
+
+    monkeypatch.setattr(
+        validation, "_allowed_confluence_hosts", lambda db: {"uipath.atlassian.net"}
+    )
+    monkeypatch.setattr(
+        validation,
+        "_first_confluence_credential",
+        lambda db: {"confluence_username": "u", "confluence_access_token": "t"},
+    )
+    monkeypatch.setattr(atlassian_mod, "Confluence", _DenyConfluence)
+    r = validate_confluence_url(
+        "https://uipath.atlassian.net/wiki/spaces/DEV/pages/123/T", None  # type: ignore[arg-type]
+    )
+    assert not r.valid
+    assert "Page not found" in r.message
+    assert "secret" not in r.message  # no token/exception leakage
 
 
 def test_confluence_url_space_inaccessible(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/danswer/onboarding/test_validation.py
+++ b/backend/tests/unit/danswer/onboarding/test_validation.py
@@ -244,6 +244,55 @@ def test_slack_channel_from_mention(monkeypatch: pytest.MonkeyPatch) -> None:
     assert validate_slack_channel("<#C0ABC123|help-team>").valid
 
 
+def test_slack_channel_link_member(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_bot(
+        monkeypatch,
+        _SlackClient(info={"id": "C1", "name": "help-team", "is_member": True}),
+    )
+    r = validate_slack_channel("https://x.slack.com/archives/C1")
+    assert r.valid
+    assert "already in this channel" in r.message
+
+
+def test_slack_channel_link_public_not_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_bot(
+        monkeypatch,
+        _SlackClient(
+            info={
+                "id": "C1",
+                "name": "help-team",
+                "is_member": False,
+                "is_private": False,
+            }
+        ),
+    )
+    r = validate_slack_channel("https://x.slack.com/archives/C1")
+    assert r.valid
+    assert "auto-join" in r.message  # public -> connector self-joins
+
+
+def test_slack_channel_link_private_not_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_bot(
+        monkeypatch,
+        _SlackClient(
+            info={
+                "id": "C1",
+                "name": "secret",
+                "is_member": False,
+                "is_private": True,
+            }
+        ),
+    )
+    r = validate_slack_channel("https://x.slack.com/archives/C1")
+    assert r.valid
+    assert "invite" in r.message.lower()
+    assert "private" in r.message.lower()  # private -> must be invited
+
+
 def test_slack_channel_bad_id_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_bot(monkeypatch, _SlackClient(info_error="channel_not_found"))
     r = validate_slack_channel("C0DEADBEEF")
@@ -269,7 +318,7 @@ def test_slack_channel_bare_name_not_member_accepted(
     _patch_bot(monkeypatch, _SlackClient(member_channels=[]))
     r = validate_slack_channel("brand-new-channel")
     assert r.valid
-    assert "will be added" in r.message
+    assert "auto-join" in r.message  # public auto-join; private needs an invite
     assert r.resolved["channel_name"] == "brand-new-channel"
 
 

--- a/backend/tests/unit/danswer/onboarding/test_validation.py
+++ b/backend/tests/unit/danswer/onboarding/test_validation.py
@@ -4,8 +4,10 @@ Slack/Confluence validators hit live APIs and are covered by manual/integration
 checks, not here."""
 import pytest
 
+from danswer.onboarding import validation
 from danswer.onboarding.validation import validate_docs_url
 from danswer.onboarding.validation import validate_github_repo
+from danswer.onboarding.validation import validate_jira_filter
 
 
 class _Cred:
@@ -119,3 +121,69 @@ def test_github_repo_inaccessible_reports_generic_error(
     assert not r.valid
     assert "not found or the GitHub app lacks access" in r.message
     assert "ghp_" not in r.message  # no token / raw payload leakage
+
+
+# --- validate_jira_filter -------------------------------------------------
+
+
+def test_jira_filter_empty() -> None:
+    assert not validate_jira_filter("", db_session=None).valid  # type: ignore[arg-type]
+
+
+def test_jira_filter_unverified_without_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(validation, "jira_base_url", lambda db: None)
+    monkeypatch.setattr(validation, "_first_jira_credential", lambda db: None)
+    r = validate_jira_filter("project = ABC", db_session=None)  # type: ignore[arg-type]
+    assert r.valid
+    assert "unverified" in r.message.lower()
+
+
+def test_jira_filter_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jira as jira_mod
+
+    class _OkJira:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def search_issues(self, jql: str, maxResults: int = 1) -> list:
+            return []
+
+    monkeypatch.setattr(
+        validation, "jira_base_url", lambda db: "https://x.atlassian.net"
+    )
+    monkeypatch.setattr(
+        validation,
+        "_first_jira_credential",
+        lambda db: {"jira_api_token": "t", "jira_user_email": "e@x.com"},
+    )
+    monkeypatch.setattr(jira_mod, "JIRA", _OkJira)
+    r = validate_jira_filter("project = ABC", db_session=None)  # type: ignore[arg-type]
+    assert r.valid
+    assert r.message == "Jira filter OK"
+
+
+def test_jira_filter_invalid_reports_generic_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import jira as jira_mod
+
+    class _BadJira:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        def search_issues(self, jql: str, maxResults: int = 1) -> list:
+            raise Exception("400 bad JQL token=ghp_should_not_leak")
+
+    monkeypatch.setattr(
+        validation, "jira_base_url", lambda db: "https://x.atlassian.net"
+    )
+    monkeypatch.setattr(
+        validation, "_first_jira_credential", lambda db: {"jira_api_token": "t"}
+    )
+    monkeypatch.setattr(jira_mod, "JIRA", _BadJira)
+    r = validate_jira_filter("nonsense jql", db_session=None)  # type: ignore[arg-type]
+    assert not r.valid
+    assert "Invalid Jira filter" in r.message
+    assert "token=" not in r.message  # no payload/token leakage

--- a/k8s/overlays/prod/env.properties
+++ b/k8s/overlays/prod/env.properties
@@ -190,6 +190,13 @@ DANSWER_BOT_RESPOND_EVERY_CHANNEL=
 DANSWER_BOT_DISABLE_COT=
 NOTIFY_SLACKBOT_NO_ANSWER=
 
+# --- Onboarding notifications ---
+# Internal ops channel (admin review link + error details): #darwin-devs.
+ONBOARDING_NOTIFY_CHANNEL=C07B2V8E99S
+# Customer-facing thread (requester @mentioned; lifecycle updates as replies):
+# #help-darwin.
+ONBOARDING_CLIENT_CHANNEL=C077AFEGCKZ
+
 # --- SMTP (non-secret bits) ---
 SMTP_SERVER=
 SMTP_PORT=

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -30,7 +30,7 @@ namespace: darwin
 images:
   - name: danswer-backend
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-backend
-    newTag: vha-217
+    newTag: vha-218
   - name: danswer-web-server
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-web-server
     newTag: vha-116

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -30,7 +30,7 @@ namespace: darwin
 images:
   - name: danswer-backend
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-backend
-    newTag: vha-216
+    newTag: vha-217
   - name: danswer-web-server
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-web-server
     newTag: vha-116

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -30,10 +30,10 @@ namespace: darwin
 images:
   - name: danswer-backend
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-backend
-    newTag: vha-218
+    newTag: vha-219
   - name: danswer-web-server
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-web-server
-    newTag: vha-116
+    newTag: vha-117
   - name: danswer-model-server
     newName: danswer/danswer-model-server
     newTag: v0.3.94

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -30,7 +30,7 @@ namespace: darwin
 images:
   - name: danswer-backend
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-backend
-    newTag: vha-219
+    newTag: vha-220
   - name: danswer-web-server
     newName: sfbrdevhelmweacr.azurecr.io/danswer/danswer-web-server
     newTag: vha-117

--- a/web/src/app/admin/bot/SlackBotConfigCreationForm.tsx
+++ b/web/src/app/admin/bot/SlackBotConfigCreationForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrayHelpers, FieldArray, Form, Formik } from "formik";
+import { FiCheck } from "react-icons/fi";
 import * as Yup from "yup";
 import { usePopup } from "@/components/admin/connectors/Popup";
 import { DocumentSet, SlackBotConfig } from "@/lib/types";
@@ -542,17 +543,19 @@ export const SlackBotCreationForm = ({
                                     key={documentSet.id}
                                     className={
                                       `
-                                      px-3 
+                                      px-3
                                       py-1
-                                      rounded-lg 
+                                      rounded-lg
                                       border
-                                      border-border 
-                                      w-fit 
-                                      flex 
-                                      cursor-pointer ` +
+                                      w-fit
+                                      flex
+                                      items-center
+                                      gap-1.5
+                                      cursor-pointer
+                                      transition-colors ` +
                                       (isSelected
-                                        ? " bg-hover"
-                                        : " bg-background hover:bg-hover-light")
+                                        ? " border-accent bg-accent/10 font-medium text-accent"
+                                        : " border-border bg-background text-default hover:bg-hover-light")
                                     }
                                     onClick={() => {
                                       if (isSelected) {
@@ -562,6 +565,9 @@ export const SlackBotCreationForm = ({
                                       }
                                     }}
                                   >
+                                    {isSelected && (
+                                      <FiCheck className="h-3.5 w-3.5 shrink-0" />
+                                    )}
                                     <div className="my-auto">
                                       {documentSet.name}
                                     </div>

--- a/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
+++ b/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import {
   OnboardingRequestSnapshot,
   OnboardingStatusResponse,
@@ -120,7 +121,13 @@ export function OnboardingRequestsTable() {
           )}
 
           {req.status === "pending" && (
-            <div className="mt-3 flex gap-2">
+            <div className="mt-3 flex items-center gap-2">
+              <Link
+                href={`/admin/onboarding/${req.id}`}
+                className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-default hover:bg-hover"
+              >
+                Open / edit
+              </Link>
               <button
                 disabled={busy === req.id}
                 onClick={() => decide(req.id, "approve")}

--- a/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
+++ b/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
@@ -6,6 +6,35 @@ import {
   OnboardingRequestSnapshot,
   OnboardingStatusResponse,
 } from "@/lib/onboarding/interfaces";
+import { SourceStatusSummary } from "@/app/onboarding/SourceStatusSummary";
+import { OnboardingJourney } from "@/app/onboarding/OnboardingJourney";
+
+type FilterKey =
+  "active" | "pending" | "in_progress" | "failed" | "complete" | "all";
+
+const FILTERS: {
+  key: FilterKey;
+  label: string;
+  match: (s: string) => boolean;
+}[] = [
+  {
+    key: "active",
+    label: "Active",
+    // Anything not finished — needs attention.
+    match: (s) => !["complete", "rejected", "cancelled"].includes(s),
+  },
+  { key: "pending", label: "Pending", match: (s) => s === "pending" },
+  {
+    key: "in_progress",
+    label: "In progress",
+    match: (s) => ["provisioning", "indexing"].includes(s),
+  },
+  { key: "failed", label: "Failed", match: (s) => s === "failed" },
+  { key: "complete", label: "Complete", match: (s) => s === "complete" },
+  { key: "all", label: "All", match: () => true },
+];
+
+const PAGE_SIZE = 10;
 
 function Badge({ status }: { status: string }) {
   const color =
@@ -28,14 +57,29 @@ export function OnboardingRequestsTable() {
   >({});
   const [busy, setBusy] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Default view hides finished requests (complete/rejected/cancelled) so the
+  // queue stays focused on what needs attention; switchable + paginated so the
+  // page stays usable well past 10+ requests.
+  const [filter, setFilter] = useState<FilterKey>("active");
+  const [page, setPage] = useState(0);
 
   async function refresh() {
     const r = await fetch("/api/admin/onboarding");
-    if (r.ok) setRequests((await r.json()) as OnboardingRequestSnapshot[]);
+    if (!r.ok) return;
+    const data = (await r.json()) as OnboardingRequestSnapshot[];
+    setRequests(data);
+    // Auto-load per-source scrape status for provisioned requests so the journey
+    // + rollup populate without a manual "Refresh scrape status" click.
+    await Promise.all(
+      data
+        .filter((req) => (req.cc_pair_ids?.length ?? 0) > 0)
+        .map((req) => loadStatus(req.id))
+    );
   }
 
   useEffect(() => {
     void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function decide(id: number, action: "approve" | "reject") {
@@ -75,108 +119,196 @@ export function OnboardingRequestsTable() {
     return <p className="text-sm text-subtle">No onboarding requests yet.</p>;
   }
 
+  const activeFilter = FILTERS.find((f) => f.key === filter) ?? FILTERS[0];
+  const filtered = requests.filter((r) => activeFilter.match(r.status));
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const clampedPage = Math.min(page, totalPages - 1);
+  const pageItems = filtered.slice(
+    clampedPage * PAGE_SIZE,
+    clampedPage * PAGE_SIZE + PAGE_SIZE
+  );
+
   return (
     <div>
       {error && <p className="mb-3 text-sm text-error">{error}</p>}
-      {requests.map((req) => (
-        <div
-          key={req.id}
-          className="mb-4 rounded-lg border border-border-medium p-4"
-        >
-          <div className="flex items-center justify-between">
-            <div>
-              <div className="text-sm font-semibold text-default">
-                {req.payload.team_name} → #{req.payload.channel.channel_name}
-              </div>
-              <div className="text-xs text-subtle">
-                by {req.requester_email} ·{" "}
-                {new Date(req.created_at).toLocaleString()}
-              </div>
-            </div>
-            <Badge status={req.status} />
-          </div>
 
-          <div className="mt-2 text-xs text-subtle">
-            <span className="font-medium text-default">Sources:</span>{" "}
-            {req.payload.sources
-              .map((s) => `${s.type}:${s.label || s.value}`)
-              .join(", ")}
-          </div>
-          <div className="mt-1 text-xs text-subtle">
-            SME:{" "}
-            {req.payload.sme.enabled
-              ? req.payload.sme.group_name || "yes"
-              : "no"}{" "}
-            · On-call:{" "}
-            {req.payload.oncall.enabled
-              ? req.payload.oncall.schedule || "yes"
-              : "no"}{" "}
-            · Jira:{" "}
-            {req.payload.jira.enabled
-              ? req.payload.jira.project_key || "yes"
-              : "no"}
-          </div>
-          {req.error_msg && (
-            <p className="mt-1 text-xs text-error">{req.error_msg}</p>
-          )}
+      {/* Filter bar */}
+      <div className="mb-4 flex flex-wrap items-center gap-1">
+        {FILTERS.map((f) => {
+          const count = requests.filter((r) => f.match(r.status)).length;
+          const selected = f.key === filter;
+          return (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => {
+                setFilter(f.key);
+                setPage(0);
+              }}
+              className={
+                `rounded-full border px-3 py-1 text-xs font-medium transition-colors ` +
+                (selected
+                  ? " border-accent bg-accent/10 text-accent"
+                  : " border-border-medium text-subtle hover:bg-hover-light")
+              }
+            >
+              {f.label} ({count})
+            </button>
+          );
+        })}
+      </div>
 
-          {req.status === "pending" && (
-            <div className="mt-3 flex items-center gap-2">
-              <Link
-                href={`/admin/onboarding/${req.id}`}
-                className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-default hover:bg-hover"
-              >
-                Open / edit
-              </Link>
-              <button
-                disabled={busy === req.id}
-                onClick={() => decide(req.id, "approve")}
-                className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-inverted disabled:opacity-60"
-              >
-                {busy === req.id ? "Provisioning…" : "Approve & provision"}
-              </button>
-              <button
-                disabled={busy === req.id}
-                onClick={() => decide(req.id, "reject")}
-                className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-default hover:bg-hover"
-              >
-                Reject
-              </button>
-            </div>
-          )}
-
-          {(req.cc_pair_ids?.length ?? 0) > 0 && (
-            <div className="mt-3">
-              <button
-                onClick={() => loadStatus(req.id)}
-                className="text-xs text-link hover:underline"
-              >
-                Refresh scrape status
-              </button>
-              {statuses[req.id]?.sources.map((s) => (
-                <div
-                  key={s.cc_pair_id}
-                  className="mt-1 flex items-center justify-between text-xs"
-                >
-                  <Link
-                    href={`/admin/connector/${s.cc_pair_id}`}
-                    className="text-link hover:underline"
-                    title="Open this connector to see full indexing status"
-                  >
-                    {s.name}
-                  </Link>
-                  <span>
-                    <Badge status={s.status} /> · {s.docs_indexed} docs
-                    {s.error_msg ? (
-                      <span className="text-error"> · {s.error_msg}</span>
-                    ) : null}
-                  </span>
+      {filtered.length === 0 ? (
+        <p className="text-sm text-subtle">
+          No {activeFilter.label.toLowerCase()} onboarding requests.
+        </p>
+      ) : (
+        pageItems.map((req) => (
+          <div
+            key={req.id}
+            className="mb-4 rounded-lg border border-border-medium p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold text-default">
+                  {req.payload.team_name} → #{req.payload.channel.channel_name}
                 </div>
-              ))}
+                <div className="text-xs text-subtle">
+                  by {req.requester_email} ·{" "}
+                  {new Date(req.created_at).toLocaleString()}
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-1">
+                <Badge status={req.status} />
+                {statuses[req.id] && (
+                  <SourceStatusSummary sources={statuses[req.id].sources} />
+                )}
+              </div>
             </div>
-          )}
+
+            <OnboardingJourney
+              request={req}
+              sources={statuses[req.id]?.sources}
+              admin
+            />
+
+            <div className="mt-2 text-xs text-subtle">
+              <span className="font-medium text-default">Sources:</span>{" "}
+              {req.payload.sources
+                .map((s) => `${s.type}:${s.label || s.value}`)
+                .join(", ")}
+            </div>
+            <div className="mt-1 text-xs text-subtle">
+              SME:{" "}
+              {req.payload.sme.enabled
+                ? req.payload.sme.group_name || "yes"
+                : "no"}{" "}
+              · On-call:{" "}
+              {req.payload.oncall.enabled
+                ? req.payload.oncall.schedule || "yes"
+                : "no"}{" "}
+              · Jira:{" "}
+              {req.payload.jira.enabled
+                ? req.payload.jira.project_key || "yes"
+                : "no"}
+            </div>
+            {req.error_msg && (
+              <p className="mt-1 text-xs text-error">{req.error_msg}</p>
+            )}
+
+            {req.status === "pending" && (
+              <div className="mt-3 flex items-center gap-2">
+                <Link
+                  href={`/admin/onboarding/${req.id}`}
+                  className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-default hover:bg-hover"
+                >
+                  Open / edit
+                </Link>
+                <button
+                  disabled={busy === req.id}
+                  onClick={() => decide(req.id, "approve")}
+                  className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-inverted disabled:opacity-60"
+                >
+                  {busy === req.id ? "Provisioning…" : "Approve & provision"}
+                </button>
+                <button
+                  disabled={busy === req.id}
+                  onClick={() => decide(req.id, "reject")}
+                  className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-default hover:bg-hover"
+                >
+                  Reject
+                </button>
+              </div>
+            )}
+
+            {(req.cc_pair_ids?.length ?? 0) > 0 && (
+              <div className="mt-3">
+                <button
+                  onClick={() => loadStatus(req.id)}
+                  className="text-xs text-link hover:underline"
+                >
+                  Refresh scrape status
+                </button>
+                {statuses[req.id]?.sources.map((s) => (
+                  <div key={s.cc_pair_id} className="mt-1 text-xs">
+                    <div className="flex items-start gap-2">
+                      <Link
+                        href={`/admin/connector/${s.cc_pair_id}`}
+                        className="min-w-0 flex-1 text-link hover:underline [overflow-wrap:anywhere]"
+                        title="Open this connector to see full indexing status"
+                      >
+                        {s.name}
+                      </Link>
+                      <span className="w-24 shrink-0">
+                        <Badge status={s.status} />
+                      </span>
+                      <span className="w-16 shrink-0 text-right text-subtle">
+                        {s.docs_indexed} docs
+                      </span>
+                    </div>
+                    {s.error_msg && (
+                      <p className="mt-0.5 [overflow-wrap:anywhere] text-error">
+                        {s.error_msg}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-xs text-subtle">
+          <span>
+            Showing {clampedPage * PAGE_SIZE + 1}–
+            {Math.min((clampedPage + 1) * PAGE_SIZE, filtered.length)} of{" "}
+            {filtered.length}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={clampedPage === 0}
+              onClick={() => setPage(clampedPage - 1)}
+              className="rounded-md border border-border-medium px-2 py-1 hover:bg-hover-light disabled:opacity-40"
+            >
+              Prev
+            </button>
+            <span>
+              Page {clampedPage + 1} / {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={clampedPage >= totalPages - 1}
+              onClick={() => setPage(clampedPage + 1)}
+              className="rounded-md border border-border-medium px-2 py-1 hover:bg-hover-light disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
         </div>
-      ))}
+      )}
     </div>
   );
 }

--- a/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
+++ b/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
@@ -158,7 +158,13 @@ export function OnboardingRequestsTable() {
                   key={s.cc_pair_id}
                   className="mt-1 flex items-center justify-between text-xs"
                 >
-                  <span className="text-subtle">{s.name}</span>
+                  <Link
+                    href={`/admin/connector/${s.cc_pair_id}`}
+                    className="text-link hover:underline"
+                    title="Open this connector to see full indexing status"
+                  >
+                    {s.name}
+                  </Link>
                   <span>
                     <Badge status={s.status} /> · {s.docs_indexed} docs
                     {s.error_msg ? (

--- a/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
+++ b/web/src/app/admin/onboarding/OnboardingRequestsTable.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  OnboardingRequestSnapshot,
+  OnboardingStatusResponse,
+} from "@/lib/onboarding/interfaces";
+
+function Badge({ status }: { status: string }) {
+  const color =
+    status === "complete"
+      ? "text-link"
+      : status === "failed" || status === "rejected"
+        ? "text-error"
+        : status === "pending"
+          ? "text-default"
+          : "text-subtle";
+  return (
+    <span className={`text-xs font-semibold uppercase ${color}`}>{status}</span>
+  );
+}
+
+export function OnboardingRequestsTable() {
+  const [requests, setRequests] = useState<OnboardingRequestSnapshot[]>([]);
+  const [statuses, setStatuses] = useState<
+    Record<number, OnboardingStatusResponse>
+  >({});
+  const [busy, setBusy] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    const r = await fetch("/api/admin/onboarding");
+    if (r.ok) setRequests((await r.json()) as OnboardingRequestSnapshot[]);
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  async function decide(id: number, action: "approve" | "reject") {
+    setError(null);
+    let reason: string | null = null;
+    if (action === "reject") {
+      reason = window.prompt("Reason for rejecting (optional)?") || null;
+    }
+    setBusy(id);
+    try {
+      const r = await fetch(`/api/admin/onboarding/${id}/${action}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(action === "reject" ? { reason } : {}),
+      });
+      if (!r.ok) {
+        setError(
+          (await r.json().catch(() => null))?.detail || `Failed (${r.status}).`
+        );
+        return;
+      }
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function loadStatus(id: number) {
+    const r = await fetch(`/api/onboarding/${id}/status`);
+    if (r.ok) {
+      const data = (await r.json()) as OnboardingStatusResponse;
+      setStatuses((p) => ({ ...p, [id]: data }));
+    }
+  }
+
+  if (requests.length === 0) {
+    return <p className="text-sm text-subtle">No onboarding requests yet.</p>;
+  }
+
+  return (
+    <div>
+      {error && <p className="mb-3 text-sm text-error">{error}</p>}
+      {requests.map((req) => (
+        <div
+          key={req.id}
+          className="mb-4 rounded-lg border border-border-medium p-4"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-semibold text-default">
+                {req.payload.team_name} → #{req.payload.channel.channel_name}
+              </div>
+              <div className="text-xs text-subtle">
+                by {req.requester_email} ·{" "}
+                {new Date(req.created_at).toLocaleString()}
+              </div>
+            </div>
+            <Badge status={req.status} />
+          </div>
+
+          <div className="mt-2 text-xs text-subtle">
+            <span className="font-medium text-default">Sources:</span>{" "}
+            {req.payload.sources
+              .map((s) => `${s.type}:${s.label || s.value}`)
+              .join(", ")}
+          </div>
+          <div className="mt-1 text-xs text-subtle">
+            SME:{" "}
+            {req.payload.sme.enabled
+              ? req.payload.sme.group_name || "yes"
+              : "no"}{" "}
+            · On-call:{" "}
+            {req.payload.oncall.enabled
+              ? req.payload.oncall.schedule || "yes"
+              : "no"}{" "}
+            · Jira:{" "}
+            {req.payload.jira.enabled
+              ? req.payload.jira.project_key || "yes"
+              : "no"}
+          </div>
+          {req.error_msg && (
+            <p className="mt-1 text-xs text-error">{req.error_msg}</p>
+          )}
+
+          {req.status === "pending" && (
+            <div className="mt-3 flex gap-2">
+              <button
+                disabled={busy === req.id}
+                onClick={() => decide(req.id, "approve")}
+                className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-inverted disabled:opacity-60"
+              >
+                {busy === req.id ? "Provisioning…" : "Approve & provision"}
+              </button>
+              <button
+                disabled={busy === req.id}
+                onClick={() => decide(req.id, "reject")}
+                className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-default hover:bg-hover"
+              >
+                Reject
+              </button>
+            </div>
+          )}
+
+          {(req.cc_pair_ids?.length ?? 0) > 0 && (
+            <div className="mt-3">
+              <button
+                onClick={() => loadStatus(req.id)}
+                className="text-xs text-link hover:underline"
+              >
+                Refresh scrape status
+              </button>
+              {statuses[req.id]?.sources.map((s) => (
+                <div
+                  key={s.cc_pair_id}
+                  className="mt-1 flex items-center justify-between text-xs"
+                >
+                  <span className="text-subtle">{s.name}</span>
+                  <span>
+                    <Badge status={s.status} /> · {s.docs_indexed} docs
+                    {s.error_msg ? (
+                      <span className="text-error"> · {s.error_msg}</span>
+                    ) : null}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/admin/onboarding/[id]/page.tsx
+++ b/web/src/app/admin/onboarding/[id]/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { OnboardingForm } from "@/app/onboarding/OnboardingForm";
+import { OnboardingRequestSnapshot } from "@/lib/onboarding/interfaces";
+
+// Admin opens a pending request in the shared onboarding form (prefilled) to fix
+// gaps and approve. Gated by the /admin layout (admin-only).
+export default function Page({ params }: { params: { id: string } }) {
+  const [request, setRequest] = useState<OnboardingRequestSnapshot | null>(
+    null
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/admin/onboarding/${params.id}`)
+      .then(async (r) => {
+        if (!r.ok) {
+          setError(`Couldn't load request (${r.status}).`);
+          return;
+        }
+        setRequest((await r.json()) as OnboardingRequestSnapshot);
+      })
+      .catch(() => setError("Couldn't load request."));
+  }, [params.id]);
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 text-sm text-error">
+        {error}
+      </div>
+    );
+  }
+  if (!request) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 text-sm text-subtle">
+        Loading…
+      </div>
+    );
+  }
+  return (
+    // Suspense: OnboardingForm reads useSearchParams; the admin layout doesn't
+    // wrap children in one, so provide it here for the prod build.
+    <Suspense fallback={null}>
+      <OnboardingForm initialRequest={request} />
+    </Suspense>
+  );
+}

--- a/web/src/app/admin/onboarding/page.tsx
+++ b/web/src/app/admin/onboarding/page.tsx
@@ -1,0 +1,19 @@
+import { AdminPageTitle } from "@/components/admin/Title";
+import { RobotIcon } from "@/components/icons/icons";
+import { OnboardingRequestsTable } from "./OnboardingRequestsTable";
+
+export default function Page() {
+  return (
+    <div className="mx-auto container">
+      <AdminPageTitle
+        icon={<RobotIcon size={32} />}
+        title="Onboarding requests"
+      />
+      <p className="text-sm text-subtle mb-4">
+        Approve a request to auto-provision the team&apos;s assistant, sources
+        (scraped with bumped priority), and Slack bot config.
+      </p>
+      <OnboardingRequestsTable />
+    </div>
+  );
+}

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -1422,7 +1422,9 @@ export function ChatPage({
                                   content={message.message}
                                   files={message.files}
                                   query={messageHistory[i]?.query || undefined}
-                                  personaName={assistantDisplayName(livePersona)}
+                                  personaName={assistantDisplayName(
+                                    livePersona
+                                  )}
                                   citedDocuments={getCitedDocumentsFromMessage(
                                     message
                                   )}
@@ -1532,7 +1534,9 @@ export function ChatPage({
                                 <AIMessage
                                   currentPersona={livePersona}
                                   messageId={message.messageId}
-                                  personaName={assistantDisplayName(livePersona)}
+                                  personaName={assistantDisplayName(
+                                    livePersona
+                                  )}
                                   content={
                                     <p className="text-red-700 text-sm my-auto">
                                       {message.message}

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -49,7 +49,8 @@ import { DocumentSidebar } from "./documentSidebar/DocumentSidebar";
 import { DanswerInitializingLoader } from "@/components/DanswerInitializingLoader";
 import { FeedbackModal } from "./modal/FeedbackModal";
 import { ShareChatSessionModal } from "./modal/ShareChatSessionModal";
-import { FiArrowDown, FiShare2 } from "react-icons/fi";
+import { FiArrowDown, FiShare2, FiUserPlus } from "react-icons/fi";
+import Link from "next/link";
 import { ChatIntro } from "./ChatIntro";
 import { AIMessage, HumanMessage } from "./message/Messages";
 import { ThreeDots } from "react-loader-spinner";
@@ -1278,6 +1279,20 @@ export function ChatPage({
                         <div className="sticky top-0 left-80 z-10 w-full bg-background flex">
                           <div className="mt-2 flex w-full">
                             <div className="ml-auto mr-6 flex">
+                              <Link
+                                href="/onboarding"
+                                title="Onboard a team to Darwin"
+                                className={`
+                                    my-auto
+                                    p-2
+                                    rounded
+                                    cursor-pointer
+                                    hover:bg-hover-light
+                                  `}
+                              >
+                                <FiUserPlus size="18" />
+                              </Link>
+
                               {chatSessionIdRef.current !== null && (
                                 <div
                                   onClick={() => setSharingModalVisible(true)}

--- a/web/src/app/chat/sessionSidebar/ChatSidebar.tsx
+++ b/web/src/app/chat/sessionSidebar/ChatSidebar.tsx
@@ -4,6 +4,7 @@ import {
   FiBook,
   FiEdit,
   FiFolderPlus,
+  FiList,
   FiLoader,
   FiPlusSquare,
   FiUserPlus,
@@ -197,6 +198,16 @@ export const ChatSidebar = ({
             <BasicClickable fullWidth>
               <div className="flex items-center text-default font-medium">
                 <FiUserPlus className="ml-1 mr-2" /> Onboard a Team
+              </div>
+            </BasicClickable>
+          </Link>
+        </div>
+
+        <div className="mt-1 mb-1 mx-3">
+          <Link href="/onboarding?view=requests">
+            <BasicClickable fullWidth>
+              <div className="flex items-center text-default font-medium">
+                <FiList className="ml-1 mr-2" /> My onboarding requests
               </div>
             </BasicClickable>
           </Link>

--- a/web/src/app/chat/sessionSidebar/ChatSidebar.tsx
+++ b/web/src/app/chat/sessionSidebar/ChatSidebar.tsx
@@ -6,6 +6,7 @@ import {
   FiFolderPlus,
   FiLoader,
   FiPlusSquare,
+  FiUserPlus,
 } from "react-icons/fi";
 import { useContext, useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
@@ -189,6 +190,16 @@ export const ChatSidebar = ({
               {isNavigatingAssistants ? "Loading…" : "Manage Assistants"}
             </div>
           </BasicClickable>
+        </div>
+
+        <div className="mt-1 mb-1 mx-3">
+          <Link href="/onboarding">
+            <BasicClickable fullWidth>
+              <div className="flex items-center text-default font-medium">
+                <FiUserPlus className="ml-1 mr-2" /> Onboard a Team
+              </div>
+            </BasicClickable>
+          </Link>
         </div>
 
         <div className="border-b border-border pb-4 mx-3" />

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -107,7 +107,7 @@ function SourceRow({
   const kindFor: Record<OnboardingSourceType, ValidateKind> = {
     web: "docs",
     confluence: "confluence",
-    github: "docs", // github URLs aren't live-validated; format-check only
+    github: "github", // live-validated: confirms the stored token can reach the repo
     slack: "slack_channel",
   };
   const [result, setResult] = useState<ValidationResult | null>(null);
@@ -135,7 +135,7 @@ function SourceRow({
             setResult(null);
           }}
           onBlur={async () => {
-            if (!source.value.trim() || source.type === "github") return;
+            if (!source.value.trim()) return;
             setResult(
               await validateOnboardingField(kindFor[source.type], source.value)
             );

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -418,6 +418,7 @@ export function OnboardingForm() {
   const [smeGroup, setSmeGroup] = useState("");
   const [oncallEnabled, setOncallEnabled] = useState(false);
   const [oncallSchedule, setOncallSchedule] = useState("");
+  const [oncallHandles, setOncallHandles] = useState("");
 
   const [docsCloud, setDocsCloud] = useState("");
   const [docsOnprem, setDocsOnprem] = useState("");
@@ -500,7 +501,11 @@ export function OnboardingForm() {
           system_prompt: systemPrompt,
           task_prompt: "",
           sme: { enabled: smeEnabled, group_name: smeGroup },
-          oncall: { enabled: oncallEnabled, schedule: oncallSchedule },
+          oncall: {
+            enabled: oncallEnabled,
+            schedule: oncallSchedule,
+            handles: oncallHandles,
+          },
           sources,
         }),
       });
@@ -680,12 +685,27 @@ export function OnboardingForm() {
           On &quot;need more help&quot;, tag the on-call
         </label>
         {oncallEnabled && (
-          <input
-            value={oncallSchedule}
-            onChange={(e) => setOncallSchedule(e.target.value)}
-            placeholder="Opsgenie schedule name"
-            className={`${inputClass} mt-3`}
-          />
+          <div className="mt-3">
+            <ValidatedField
+              label="DRI Slack handle(s)"
+              placeholder="@as-dri (comma-separated for multiple)"
+              kind="slack_group"
+              value={oncallHandles}
+              onChange={setOncallHandles}
+              helpText="Slack user-group handle(s) to @-mention when someone needs more help, e.g. @as-dri."
+              optional
+            />
+            <input
+              value={oncallSchedule}
+              onChange={(e) => setOncallSchedule(e.target.value)}
+              placeholder="OpsGenie schedule name (optional)"
+              className={inputClass}
+            />
+            <p className="mt-1.5 text-xs text-subtle">
+              Optionally pull the current DRI from an OpsGenie schedule instead
+              of (or in addition to) the handles above.
+            </p>
+          </div>
         )}
       </Section>
 

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -1,0 +1,579 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  OnboardingRequestSnapshot,
+  OnboardingSource,
+  OnboardingSourceType,
+  OnboardingStatusResponse,
+  validateOnboardingField,
+  ValidateKind,
+  ValidationResult,
+} from "@/lib/onboarding/interfaces";
+
+// --- inline-validated text field --------------------------------------------
+
+function ValidatedField({
+  label,
+  placeholder,
+  kind,
+  value,
+  onChange,
+  onResolved,
+  optional,
+}: {
+  label: string;
+  placeholder?: string;
+  kind: ValidateKind;
+  value: string;
+  onChange: (v: string) => void;
+  onResolved?: (r: ValidationResult) => void;
+  optional?: boolean;
+}) {
+  const [result, setResult] = useState<ValidationResult | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  async function check() {
+    if (!value.trim()) {
+      setResult(null);
+      return;
+    }
+    setChecking(true);
+    const r = await validateOnboardingField(kind, value);
+    setResult(r);
+    setChecking(false);
+    onResolved?.(r);
+  }
+
+  return (
+    <div className="mb-3">
+      <label className="block text-sm font-medium text-default mb-1">
+        {label}
+        {optional && (
+          <span className="text-subtle font-normal"> (optional)</span>
+        )}
+      </label>
+      <input
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setResult(null);
+        }}
+        onBlur={check}
+        className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm text-default focus:outline-none focus:ring-1 focus:ring-accent"
+      />
+      {checking && <p className="mt-1 text-xs text-subtle">Validating…</p>}
+      {result && (
+        <p
+          className={`mt-1 text-xs ${
+            result.valid ? "text-link" : "text-error"
+          }`}
+        >
+          {result.valid ? "✓ " : "✗ "}
+          {result.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// --- status badge -----------------------------------------------------------
+
+function StatusBadge({ status }: { status: string }) {
+  const color =
+    status === "complete"
+      ? "text-link"
+      : status === "failed" || status === "rejected"
+        ? "text-error"
+        : "text-subtle";
+  return <span className={`text-xs font-semibold ${color}`}>{status}</span>;
+}
+
+// --- one extra source row ---------------------------------------------------
+
+function SourceRow({
+  source,
+  onChange,
+  onRemove,
+  onMove,
+}: {
+  source: OnboardingSource;
+  onChange: (s: OnboardingSource) => void;
+  onRemove: () => void;
+  onMove: (dir: -1 | 1) => void;
+}) {
+  const kindFor: Record<OnboardingSourceType, ValidateKind> = {
+    web: "docs",
+    confluence: "confluence",
+    github: "docs", // github URLs aren't live-validated; format-check only
+    slack: "slack_channel",
+  };
+  const [result, setResult] = useState<ValidationResult | null>(null);
+  return (
+    <div className="mb-2 flex items-start gap-2">
+      <select
+        value={source.type}
+        onChange={(e) =>
+          onChange({ ...source, type: e.target.value as OnboardingSourceType })
+        }
+        className="rounded-md border border-border-medium bg-background-weak px-2 py-2 text-sm"
+      >
+        <option value="confluence">Confluence</option>
+        <option value="github">GitHub repo</option>
+        <option value="slack">Slack channel</option>
+        <option value="web">Web / docs</option>
+      </select>
+      <div className="flex-1">
+        <input
+          type="text"
+          value={source.value}
+          placeholder="URL, repo, or #channel"
+          onChange={(e) => {
+            onChange({ ...source, value: e.target.value });
+            setResult(null);
+          }}
+          onBlur={async () => {
+            if (!source.value.trim() || source.type === "github") return;
+            setResult(
+              await validateOnboardingField(kindFor[source.type], source.value)
+            );
+          }}
+          className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm"
+        />
+        {result && (
+          <p
+            className={`mt-1 text-xs ${result.valid ? "text-link" : "text-error"}`}
+          >
+            {result.valid ? "✓ " : "✗ "}
+            {result.message}
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => onMove(-1)}
+        title="Move up"
+        className="px-1 text-subtle hover:text-default"
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        onClick={() => onMove(1)}
+        title="Move down"
+        className="px-1 text-subtle hover:text-default"
+      >
+        ↓
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        title="Remove"
+        className="px-1 text-subtle hover:text-error"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+// --- main form --------------------------------------------------------------
+
+export function OnboardingForm() {
+  const [teamName, setTeamName] = useState("");
+  const [channelInput, setChannelInput] = useState("");
+  const [channel, setChannel] = useState<{ id: string; name: string } | null>(
+    null
+  );
+  const [responseType, setResponseType] = useState<"citations" | "quotes">(
+    "citations"
+  );
+  const [respondTagOnly, setRespondTagOnly] = useState(false);
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [smeEnabled, setSmeEnabled] = useState(false);
+  const [smeGroup, setSmeGroup] = useState("");
+  const [oncallEnabled, setOncallEnabled] = useState(false);
+  const [oncallSchedule, setOncallSchedule] = useState("");
+  const [jiraEnabled, setJiraEnabled] = useState(false);
+  const [jiraProject, setJiraProject] = useState("");
+  const [jiraIssueType, setJiraIssueType] = useState("");
+
+  const [docsCloud, setDocsCloud] = useState("");
+  const [docsOnprem, setDocsOnprem] = useState("");
+  const [includeHistory, setIncludeHistory] = useState(true);
+  const [extraSources, setExtraSources] = useState<OnboardingSource[]>([]);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [mine, setMine] = useState<OnboardingRequestSnapshot[]>([]);
+  const [statuses, setStatuses] = useState<
+    Record<number, OnboardingStatusResponse>
+  >({});
+
+  useEffect(() => {
+    fetch("/api/onboarding/default-prompt")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => d?.system_prompt && setSystemPrompt(d.system_prompt))
+      .catch(() => {});
+    void refreshMine();
+  }, []);
+
+  async function refreshMine() {
+    try {
+      const r = await fetch("/api/onboarding/mine");
+      if (r.ok) setMine((await r.json()) as OnboardingRequestSnapshot[]);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function loadStatus(id: number) {
+    const r = await fetch(`/api/onboarding/${id}/status`);
+    if (r.ok) {
+      const data = (await r.json()) as OnboardingStatusResponse;
+      setStatuses((prev) => ({ ...prev, [id]: data }));
+    }
+  }
+
+  function buildSources(): OnboardingSource[] {
+    const s: OnboardingSource[] = [];
+    if (docsCloud.trim())
+      s.push({ type: "web", value: docsCloud.trim(), label: "Docs (cloud)" });
+    if (docsOnprem.trim())
+      s.push({
+        type: "web",
+        value: docsOnprem.trim(),
+        label: "Docs (on-prem)",
+      });
+    if (includeHistory && channel)
+      s.push({
+        type: "slack",
+        value: channel.name,
+        label: `#${channel.name} history`,
+      });
+    extraSources.forEach((x) => x.value.trim() && s.push(x));
+    return s;
+  }
+
+  async function submit() {
+    setError(null);
+    if (!teamName.trim()) return setError("Team name is required.");
+    if (!channel) return setError("Validate the bot channel first.");
+    const sources = buildSources();
+    if (sources.length === 0) return setError("Add at least one source.");
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/onboarding", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          team_name: teamName.trim(),
+          channel: { channel_id: channel.id, channel_name: channel.name },
+          response_type: responseType,
+          respond_tag_only: respondTagOnly,
+          system_prompt: systemPrompt,
+          task_prompt: "",
+          sme: { enabled: smeEnabled, group_name: smeGroup },
+          oncall: { enabled: oncallEnabled, schedule: oncallSchedule },
+          jira: {
+            enabled: jiraEnabled,
+            project_key: jiraProject,
+            issue_type: jiraIssueType,
+            component: "",
+          },
+          sources,
+        }),
+      });
+      if (!res.ok) {
+        setError(
+          (await res.json().catch(() => null))?.detail ||
+            `Submit failed (${res.status}).`
+        );
+        return;
+      }
+      // reset the source fields; keep it simple.
+      setDocsCloud("");
+      setDocsOnprem("");
+      setExtraSources([]);
+      await refreshMine();
+    } catch {
+      setError("Something went wrong submitting the request.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const section =
+    "mb-6 rounded-lg border border-border-medium bg-background-weak p-4";
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-2xl font-semibold text-default mb-1">
+        Onboard a team to Darwin
+      </h1>
+      <p className="text-sm text-subtle mb-6">
+        Submit this request; an admin approves it, then Darwin auto-scrapes your
+        sources and wires up your assistant. Every field is validated live.
+      </p>
+
+      <div className={section}>
+        <ValidatedField
+          label="Bot channel"
+          placeholder="#help-your-team or a channel link"
+          kind="slack_channel"
+          value={channelInput}
+          onChange={setChannelInput}
+          onResolved={(r) =>
+            setChannel(
+              r.valid
+                ? {
+                    id: String(r.resolved.channel_id ?? ""),
+                    name: String(r.resolved.channel_name ?? ""),
+                  }
+                : null
+            )
+          }
+        />
+        <label className="block text-sm font-medium text-default mb-1 mt-2">
+          Team name
+        </label>
+        <input
+          value={teamName}
+          onChange={(e) => setTeamName(e.target.value)}
+          placeholder="e.g. Integration Service"
+          className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm mb-3"
+        />
+        <div className="flex items-center gap-4">
+          <label className="text-sm text-default">
+            Response format:{" "}
+            <select
+              value={responseType}
+              onChange={(e) =>
+                setResponseType(e.target.value as "citations" | "quotes")
+              }
+              className="rounded-md border border-border-medium bg-background-weak px-2 py-1 text-sm"
+            >
+              <option value="citations">Citations</option>
+              <option value="quotes">Quotes</option>
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-sm text-default">
+            <input
+              type="checkbox"
+              checked={respondTagOnly}
+              onChange={(e) => setRespondTagOnly(e.target.checked)}
+            />
+            Respond only when tagged
+          </label>
+        </div>
+      </div>
+
+      <div className={section}>
+        <h2 className="text-sm font-semibold text-default mb-2">
+          Sources (priority order)
+        </h2>
+        <ValidatedField
+          label="Documentation — Cloud (root URL)"
+          placeholder="https://docs.uipath.com/<product>/automation-cloud/latest"
+          kind="docs"
+          value={docsCloud}
+          onChange={setDocsCloud}
+          optional
+        />
+        <ValidatedField
+          label="Documentation — On-prem / standalone (root URL)"
+          placeholder="https://docs.uipath.com/<product>/standalone/latest"
+          kind="docs"
+          value={docsOnprem}
+          onChange={setDocsOnprem}
+          optional
+        />
+        <p className="text-xs text-subtle mb-3">
+          Paste the product root URL only — Darwin crawls all versions
+          automatically.
+        </p>
+        <label className="flex items-center gap-2 text-sm text-default mb-3">
+          <input
+            type="checkbox"
+            checked={includeHistory}
+            onChange={(e) => setIncludeHistory(e.target.checked)}
+          />
+          Include this channel&apos;s message history
+        </label>
+        <div className="text-sm font-medium text-default mb-1">
+          Additional sources
+        </div>
+        {extraSources.map((s, i) => (
+          <SourceRow
+            key={i}
+            source={s}
+            onChange={(ns) =>
+              setExtraSources((p) => p.map((x, j) => (j === i ? ns : x)))
+            }
+            onRemove={() => setExtraSources((p) => p.filter((_, j) => j !== i))}
+            onMove={(dir) =>
+              setExtraSources((p) => {
+                const j = i + dir;
+                if (j < 0 || j >= p.length) return p;
+                const c = [...p];
+                [c[i], c[j]] = [c[j], c[i]];
+                return c;
+              })
+            }
+          />
+        ))}
+        <button
+          type="button"
+          onClick={() =>
+            setExtraSources((p) => [...p, { type: "confluence", value: "" }])
+          }
+          className="mt-1 text-sm text-link hover:underline"
+        >
+          + Add source
+        </button>
+      </div>
+
+      <div className={section}>
+        <label className="block text-sm font-medium text-default mb-1">
+          System prompt
+        </label>
+        <p className="text-xs text-subtle mb-1">
+          Prefilled from the default (Orchestrator) — edit as needed.
+        </p>
+        <textarea
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          rows={5}
+          className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm font-mono"
+        />
+      </div>
+
+      <div className={section}>
+        <h2 className="text-sm font-semibold text-default mb-2">Options</h2>
+        <label className="flex items-center gap-2 text-sm text-default mb-2">
+          <input
+            type="checkbox"
+            checked={smeEnabled}
+            onChange={(e) => setSmeEnabled(e.target.checked)}
+          />
+          Let SMEs verify answers
+        </label>
+        {smeEnabled && (
+          <ValidatedField
+            label="SME Slack user group(s)"
+            placeholder="e.g. as-smes (comma-separated)"
+            kind="slack_group"
+            value={smeGroup}
+            onChange={setSmeGroup}
+          />
+        )}
+        <label className="flex items-center gap-2 text-sm text-default mb-2">
+          <input
+            type="checkbox"
+            checked={oncallEnabled}
+            onChange={(e) => setOncallEnabled(e.target.checked)}
+          />
+          On &quot;need more help&quot;, tag the on-call
+        </label>
+        {oncallEnabled && (
+          <input
+            value={oncallSchedule}
+            onChange={(e) => setOncallSchedule(e.target.value)}
+            placeholder="Opsgenie schedule name"
+            className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm mb-3"
+          />
+        )}
+        <label className="flex items-center gap-2 text-sm text-default mb-2">
+          <input
+            type="checkbox"
+            checked={jiraEnabled}
+            onChange={(e) => setJiraEnabled(e.target.checked)}
+          />
+          Enable Jira ticket creation
+        </label>
+        {jiraEnabled && (
+          <div className="flex gap-2">
+            <input
+              value={jiraProject}
+              onChange={(e) => setJiraProject(e.target.value)}
+              placeholder="Project key"
+              className="flex-1 rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm"
+            />
+            <input
+              value={jiraIssueType}
+              onChange={(e) => setJiraIssueType(e.target.value)}
+              placeholder="Issue type"
+              className="flex-1 rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm"
+            />
+          </div>
+        )}
+      </div>
+
+      {error && <p className="mb-3 text-sm text-error">{error}</p>}
+      <button
+        onClick={submit}
+        disabled={submitting}
+        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted disabled:opacity-60"
+      >
+        {submitting ? "Submitting…" : "Submit onboarding request"}
+      </button>
+
+      {mine.length > 0 && (
+        <div className="mt-10">
+          <h2 className="text-lg font-semibold text-default mb-3">
+            Your requests
+          </h2>
+          {mine.map((r) => (
+            <div
+              key={r.id}
+              className="mb-3 rounded-lg border border-border-medium p-3"
+            >
+              <div className="flex items-center justify-between">
+                <div className="text-sm font-medium text-default">
+                  {r.payload.team_name} → #{r.payload.channel.channel_name}
+                </div>
+                <StatusBadge status={r.status} />
+              </div>
+              {r.error_msg && (
+                <p className="mt-1 text-xs text-error">{r.error_msg}</p>
+              )}
+              {r.decision_reason && (
+                <p className="mt-1 text-xs text-subtle">
+                  Note: {r.decision_reason}
+                </p>
+              )}
+              {(r.cc_pair_ids?.length ?? 0) > 0 && (
+                <div className="mt-2">
+                  <button
+                    onClick={() => loadStatus(r.id)}
+                    className="text-xs text-link hover:underline"
+                  >
+                    Refresh scrape status
+                  </button>
+                  {statuses[r.id]?.sources.map((s) => (
+                    <div
+                      key={s.cc_pair_id}
+                      className="mt-1 flex items-center justify-between text-xs"
+                    >
+                      <span className="text-subtle">{s.name}</span>
+                      <span>
+                        <StatusBadge status={s.status} /> · {s.docs_indexed}{" "}
+                        docs
+                        {s.error_msg ? (
+                          <span className="text-error"> · {s.error_msg}</span>
+                        ) : null}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   FiCheck,
   FiChevronDown,
   FiChevronUp,
   FiInfo,
+  FiMoon,
   FiPlus,
+  FiSun,
   FiTrash2,
   FiX,
 } from "react-icons/fi";
@@ -28,6 +30,79 @@ const inputClass =
   "w-full rounded-md border border-border-medium bg-background px-3 py-2 " +
   "text-sm text-default placeholder:text-subtle focus:outline-none " +
   "focus:ring-2 focus:ring-accent/40 focus:border-accent";
+
+// How long to wait after the last keystroke before hitting the backend
+// validator (so you don't have to blur the field).
+const VALIDATE_DEBOUNCE_MS = 600;
+
+// --- lightweight, synchronous client-side format checks ---------------------
+// These catch obvious mistakes instantly (before any network round-trip) and
+// suppress the backend call until the format looks plausible. They return a
+// short hint string, or null when the value looks fine to send to the server.
+
+type ClientCheck = (value: string) => string | null;
+
+const checkChannel: ClientCheck = (v) => {
+  const raw = v.trim().replace(/^#/, "");
+  if (!raw) return null;
+  // A channel id or a pasted link/mention — let the server resolve it.
+  if (
+    /^C[A-Z0-9]{6,}$/.test(raw) ||
+    raw.includes("slack.com/") ||
+    raw.includes("<#")
+  )
+    return null;
+  if (/\s/.test(raw))
+    return "Channel names have no spaces — paste a link to be sure.";
+  if (/[A-Z]/.test(raw)) return "Channel names are lowercase.";
+  return null;
+};
+
+const checkUrl: ClientCheck = (v) =>
+  /^https?:\/\//i.test(v.trim()) ? null : "Start with https://";
+
+const checkJql: ClientCheck = (v) =>
+  v.trim().length < 3 ? "Enter a JQL filter, e.g. project = ABC" : null;
+
+const SOURCE_CLIENT_CHECK: Record<OnboardingSourceType, ClientCheck> = {
+  web: checkUrl,
+  confluence: checkUrl,
+  slack: checkChannel,
+  jira: checkJql,
+};
+
+// --- light/dark toggle ------------------------------------------------------
+// Mirrors UserDropdown: flips `.dark` on <html> and persists to the same
+// `darwin-theme` key, so the choice carries across the whole app. The page
+// already honors the global default set elsewhere — this just adds the control.
+
+function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  useEffect(() => {
+    setDark(document.documentElement.classList.contains("dark"));
+  }, []);
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    try {
+      localStorage.setItem("darwin-theme", next ? "dark" : "light");
+    } catch {
+      /* ignore */
+    }
+    document.documentElement.classList.toggle("dark", next);
+  };
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      title={dark ? "Switch to light mode" : "Switch to dark mode"}
+      aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+      className="rounded-md border border-border-medium p-2 text-subtle hover:bg-hover-light hover:text-default"
+    >
+      {dark ? <FiSun className="h-4 w-4" /> : <FiMoon className="h-4 w-4" />}
+    </button>
+  );
+}
 
 // --- small info tooltip -----------------------------------------------------
 
@@ -83,6 +158,7 @@ function ValidatedField({
   onResolved,
   optional,
   info,
+  clientCheck,
 }: {
   label: string;
   placeholder?: string;
@@ -92,21 +168,34 @@ function ValidatedField({
   onResolved?: (r: ValidationResult) => void;
   optional?: boolean;
   info?: string;
+  clientCheck?: ClientCheck;
 }) {
   const [result, setResult] = useState<ValidationResult | null>(null);
   const [checking, setChecking] = useState(false);
+  // Keep onResolved fresh without retriggering the debounce effect.
+  const onResolvedRef = useRef(onResolved);
+  onResolvedRef.current = onResolved;
 
-  async function check() {
-    if (!value.trim()) {
+  const hint = value.trim() ? (clientCheck?.(value) ?? null) : null;
+
+  // Debounced backend validation: fires VALIDATE_DEBOUNCE_MS after the last
+  // keystroke, and is skipped entirely while the local format check fails.
+  useEffect(() => {
+    if (!value.trim() || hint) {
       setResult(null);
+      onResolvedRef.current?.({ valid: false, message: "", resolved: {} });
       return;
     }
-    setChecking(true);
-    const r = await validateOnboardingField(kind, value);
-    setResult(r);
-    setChecking(false);
-    onResolved?.(r);
-  }
+    const t = setTimeout(async () => {
+      setChecking(true);
+      const r = await validateOnboardingField(kind, value);
+      setResult(r);
+      setChecking(false);
+      onResolvedRef.current?.(r);
+    }, VALIDATE_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, kind, hint]);
 
   return (
     <div className="mb-4">
@@ -125,11 +214,13 @@ function ValidatedField({
           onChange(e.target.value);
           setResult(null);
         }}
-        onBlur={check}
         className={inputClass}
       />
       {checking && <p className="mt-1.5 text-xs text-subtle">Validating…</p>}
-      <ResultLine result={result} />
+      {!checking && result && <ResultLine result={result} />}
+      {!checking && !result && hint && (
+        <p className="mt-1.5 text-xs text-subtle">{hint}</p>
+      )}
     </div>
   );
 }
@@ -184,6 +275,27 @@ function SourceRow({
   canMoveDown: boolean;
 }) {
   const [result, setResult] = useState<ValidationResult | null>(null);
+  const [checking, setChecking] = useState(false);
+  const hint = source.value.trim()
+    ? SOURCE_CLIENT_CHECK[source.type](source.value)
+    : null;
+
+  useEffect(() => {
+    if (!source.value.trim() || hint) {
+      setResult(null);
+      return;
+    }
+    const t = setTimeout(async () => {
+      setChecking(true);
+      setResult(
+        await validateOnboardingField(SOURCE_KIND[source.type], source.value)
+      );
+      setChecking(false);
+    }, VALIDATE_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [source.value, source.type, hint]);
+
   return (
     <div className="mb-2 flex items-start gap-2">
       <select
@@ -207,18 +319,13 @@ function SourceRow({
             onChange({ ...source, value: e.target.value });
             setResult(null);
           }}
-          onBlur={async () => {
-            if (!source.value.trim()) return;
-            setResult(
-              await validateOnboardingField(
-                SOURCE_KIND[source.type],
-                source.value
-              )
-            );
-          }}
           className={inputClass}
         />
-        <ResultLine result={result} />
+        {checking && <p className="mt-1.5 text-xs text-subtle">Validating…</p>}
+        {!checking && result && <ResultLine result={result} />}
+        {!checking && !result && hint && (
+          <p className="mt-1.5 text-xs text-subtle">{hint}</p>
+        )}
       </div>
       <div className="flex shrink-0 items-center">
         <button
@@ -401,18 +508,21 @@ export function OnboardingForm() {
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-10">
-      <header className="mb-8">
-        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
-          Team onboarding
-        </p>
-        <h1 className="text-2xl font-semibold text-default">
-          Onboarding Darwin to Slack Channel
-        </h1>
-        <p className="mt-2 text-sm text-subtle">
-          Point Darwin at your team&apos;s knowledge and channel. An admin
-          approves the request, then Darwin scrapes your sources and wires up
-          the assistant. Every field is checked live before you submit.
-        </p>
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
+            Team onboarding
+          </p>
+          <h1 className="text-2xl font-semibold text-default">
+            Onboarding Darwin to Slack Channel
+          </h1>
+          <p className="mt-2 text-sm text-subtle">
+            Point Darwin at your team&apos;s knowledge and channel. An admin
+            approves the request, then Darwin scrapes your sources and wires up
+            the assistant. Every field is checked live before you submit.
+          </p>
+        </div>
+        <ThemeToggle />
       </header>
 
       <Section step={1} title="Channel & assistant">
@@ -422,6 +532,7 @@ export function OnboardingForm() {
           kind="slack_channel"
           value={channelInput}
           onChange={setChannelInput}
+          clientCheck={checkChannel}
           info="This is the channel where the Darwin Slack bot will be configured — it answers questions here."
           onResolved={(r) =>
             setChannel(
@@ -456,6 +567,7 @@ export function OnboardingForm() {
           kind="docs"
           value={docsCloud}
           onChange={setDocsCloud}
+          clientCheck={checkUrl}
           optional
         />
         <ValidatedField
@@ -464,6 +576,7 @@ export function OnboardingForm() {
           kind="docs"
           value={docsOnprem}
           onChange={setDocsOnprem}
+          clientCheck={checkUrl}
           optional
         />
         <p className="mb-4 text-xs text-subtle">
@@ -572,8 +685,15 @@ export function OnboardingForm() {
       )}
       <button
         onClick={submit}
-        disabled={submitting}
-        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:opacity-60"
+        disabled={submitting || !teamName.trim() || !channel}
+        title={
+          !channel
+            ? "Validate the bot channel first"
+            : !teamName.trim()
+              ? "Enter a team name"
+              : undefined
+        }
+        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {submitting ? "Submitting…" : "Submit onboarding request"}
       </button>

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -26,6 +26,7 @@ import {
   SOURCE_CLIENT_CHECK,
 } from "@/lib/onboarding/clientChecks";
 import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
 
 // All colors come from the app's semantic theme tokens (text-default,
 // bg-background, border-border, …) so the page follows the global light/dark
@@ -172,7 +173,9 @@ function StatusBadge({ status }: { status: string }) {
       ? "bg-link/10 text-link"
       : status === "failed" || status === "rejected"
         ? "bg-error/10 text-error"
-        : "bg-accent/10 text-accent";
+        : status === "cancelled"
+          ? "bg-subtle/10 text-subtle"
+          : "bg-accent/10 text-accent";
   return (
     <span
       className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${tone}`}
@@ -347,13 +350,18 @@ function Section({
 
 export function OnboardingForm({
   initialRequest,
+  editMode = "admin",
 }: {
-  // When set, the form runs in admin "edit a pending request" mode (prefilled).
+  // When set, the form runs in "edit a pending request" mode (prefilled).
   initialRequest?: OnboardingRequestSnapshot;
+  // Who's editing: admin (save + approve) or the requester (save only).
+  editMode?: "admin" | "requester";
 } = {}) {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const adminEdit = !!initialRequest;
+  const editing = !!initialRequest;
+  const adminEdit = editing && editMode === "admin";
+  const requesterEdit = editing && editMode === "requester";
   const p = initialRequest?.payload;
 
   // "Submit a request" vs "My requests" — surfaced as top tabs so status isn't
@@ -395,7 +403,7 @@ export function OnboardingForm({
   >({});
 
   useEffect(() => {
-    if (adminEdit) return; // edit mode is fully prefilled from the request
+    if (editing) return; // edit mode is fully prefilled from the request
     fetch("/api/onboarding/default-prompt")
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => d?.system_prompt && setSystemPrompt(d.system_prompt))
@@ -426,11 +434,21 @@ export function OnboardingForm({
     }
   }
 
+  // Requester withdraws a still-pending request. Soft cancel: the backend flips
+  // status to "cancelled" (kept for the audit trail), so just refresh the list.
+  async function cancelRequest(id: number) {
+    if (!window.confirm("Cancel this onboarding request?")) return;
+    const r = await fetch(`/api/onboarding/${id}/cancel`, { method: "POST" });
+    if (r.ok) {
+      await refreshMine();
+    }
+  }
+
   // On the "My requests" tab, auto-load each request's per-source scrape status
   // (and re-poll every 15s) so the requester can see work happening without
   // clicking anything.
   useEffect(() => {
-    if (adminEdit || tab !== "requests") return;
+    if (editing || tab !== "requests") return;
     let active = true;
     const load = async () => {
       const list = await refreshMine();
@@ -509,14 +527,16 @@ export function OnboardingForm({
     return (await res.json().catch(() => null))?.detail || fallback;
   }
 
-  // Admin edit: PATCH the pending request's payload (without approving).
+  // Edit mode: PATCH the pending request's payload (admin uses the admin route,
+  // the requester their own). Does not approve.
   async function saveEdits(): Promise<boolean> {
     if (!initialRequest) return false;
     setError(null);
     setSavedNote(null);
     const payload = buildPayload();
     if (!payload) return false;
-    const res = await fetch(`/api/admin/onboarding/${initialRequest.id}`, {
+    const base = adminEdit ? "/api/admin/onboarding" : "/api/onboarding";
+    const res = await fetch(`${base}/${initialRequest.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -552,6 +572,13 @@ export function OnboardingForm({
         return;
       }
 
+      // Requester edit mode: save the edits, then back to My requests.
+      if (requesterEdit && initialRequest) {
+        if (!(await saveEdits())) return;
+        router.push("/onboarding?view=requests");
+        return;
+      }
+
       // Requester create mode.
       const res = await fetch("/api/onboarding", {
         method: "POST",
@@ -580,7 +607,11 @@ export function OnboardingForm({
     <div className="mx-auto max-w-3xl px-4 py-10">
       <header className="mb-8">
         <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
-          {adminEdit ? "Review onboarding request" : "Team onboarding"}
+          {adminEdit
+            ? "Review onboarding request"
+            : requesterEdit
+              ? "Edit onboarding request"
+              : "Team onboarding"}
         </p>
         <h1 className="text-2xl font-semibold text-default">
           Onboarding Darwin to Slack Channel
@@ -593,6 +624,12 @@ export function OnboardingForm({
             </span>
             . Fix any gaps below, then Save &amp; approve to provision.
           </p>
+        ) : requesterEdit ? (
+          <p className="mt-2 text-sm text-subtle">
+            Update the details of your pending request. Changes are saved for
+            the admin to review — the request stays pending until it&apos;s
+            approved.
+          </p>
         ) : (
           <p className="mt-2 text-sm text-subtle">
             Point Darwin at your team&apos;s knowledge and channel. An admin
@@ -602,7 +639,7 @@ export function OnboardingForm({
         )}
       </header>
 
-      {!adminEdit && (
+      {!editing && (
         <div className="mb-6 flex gap-1 border-b border-border">
           {(["form", "requests"] as const).map((t) => (
             <button
@@ -623,7 +660,7 @@ export function OnboardingForm({
         </div>
       )}
 
-      {(adminEdit || tab === "form") && (
+      {(editing || tab === "form") && (
         <>
           <Section step={1} title="Channel & assistant">
             <ValidatedField
@@ -825,12 +862,14 @@ export function OnboardingForm({
               className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {submitting
-                ? adminEdit
+                ? editing
                   ? "Saving…"
                   : "Submitting…"
                 : adminEdit
                   ? "Save & approve"
-                  : "Submit onboarding request"}
+                  : requesterEdit
+                    ? "Save changes"
+                    : "Submit onboarding request"}
             </button>
             {adminEdit && (
               <button
@@ -852,10 +891,16 @@ export function OnboardingForm({
                 Save changes
               </button>
             )}
-            {adminEdit && (
+            {editing && (
               <button
                 type="button"
-                onClick={() => router.push("/admin/onboarding")}
+                onClick={() =>
+                  router.push(
+                    adminEdit
+                      ? "/admin/onboarding"
+                      : "/onboarding?view=requests"
+                  )
+                }
                 className="text-sm text-subtle hover:text-default"
               >
                 Cancel
@@ -865,7 +910,7 @@ export function OnboardingForm({
         </>
       )}
 
-      {!adminEdit && tab === "requests" && (
+      {!editing && tab === "requests" && (
         <div>
           <h2 className="mb-3 text-lg font-semibold text-default">
             Your requests
@@ -893,6 +938,23 @@ export function OnboardingForm({
                 <p className="mt-1 text-xs text-subtle">
                   Note: {r.decision_reason}
                 </p>
+              )}
+              {r.status === "pending" && (
+                <div className="mt-3 flex items-center gap-2">
+                  <Link
+                    href={`/onboarding/${r.id}/edit`}
+                    className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-default hover:bg-hover"
+                  >
+                    Edit
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => cancelRequest(r.id)}
+                    className="rounded-md border border-border-medium px-3 py-1.5 text-xs font-medium text-error hover:bg-hover"
+                  >
+                    Cancel request
+                  </button>
+                </div>
               )}
               {(r.cc_pair_ids?.length ?? 0) > 0 && (
                 <div className="mt-2">

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -562,8 +562,7 @@ export function OnboardingForm() {
         <p className="mb-4 text-xs text-subtle">
           Paste the product root URL only. For automation-suite docs the version
           is stripped and Darwin scrapes the latest 3 versions automatically —
-          you don&apos;t need to list each version. The bot channel&apos;s own
-          message history is always indexed.
+          you don&apos;t need to list each version.
         </p>
 
         <div className="mb-2 text-sm font-medium text-default">

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -25,6 +25,8 @@ import {
   ClientCheck,
   SOURCE_CLIENT_CHECK,
 } from "@/lib/onboarding/clientChecks";
+import { SourceStatusSummary } from "@/app/onboarding/SourceStatusSummary";
+import { OnboardingJourney } from "@/app/onboarding/OnboardingJourney";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -362,6 +364,11 @@ export function OnboardingForm({
   const editing = !!initialRequest;
   const adminEdit = editing && editMode === "admin";
   const requesterEdit = editing && editMode === "requester";
+  // Only PENDING requests can be edited/approved. Once a request has moved on
+  // (provisioning/indexing/complete/failed/rejected/cancelled) the form is shown
+  // read-only — Save/Approve hidden, fields dimmed — so it's clear nothing can
+  // change from here.
+  const readOnly = editing && initialRequest!.status !== "pending";
   const p = initialRequest?.payload;
 
   // "Submit a request" vs "My requests" — surfaced as top tabs so status isn't
@@ -607,16 +614,30 @@ export function OnboardingForm({
     <div className="mx-auto max-w-3xl px-4 py-10">
       <header className="mb-8">
         <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
-          {adminEdit
-            ? "Review onboarding request"
-            : requesterEdit
-              ? "Edit onboarding request"
-              : "Team onboarding"}
+          {readOnly
+            ? "Onboarding request"
+            : adminEdit
+              ? "Review onboarding request"
+              : requesterEdit
+                ? "Edit onboarding request"
+                : "Team onboarding"}
         </p>
         <h1 className="text-2xl font-semibold text-default">
           Onboarding Darwin to Slack Channel
         </h1>
-        {adminEdit ? (
+        {readOnly ? (
+          <p className="mt-2 text-sm text-subtle">
+            Submitted by{" "}
+            <span className="font-medium text-default">
+              {initialRequest?.requester_email}
+            </span>
+            . This request is{" "}
+            <span className="font-medium capitalize text-default">
+              {initialRequest?.status}
+            </span>{" "}
+            — editing and approval are no longer available.
+          </p>
+        ) : adminEdit ? (
           <p className="mt-2 text-sm text-subtle">
             Submitted by{" "}
             <span className="font-medium text-default">
@@ -851,15 +872,20 @@ export function OnboardingForm({
           <div className="flex items-center gap-3">
             <button
               onClick={submit}
-              disabled={submitting || !teamName.trim() || !channel}
+              disabled={readOnly || submitting || !teamName.trim() || !channel}
               title={
-                !channel
-                  ? "Validate the bot channel first"
-                  : !teamName.trim()
-                    ? "Enter a team name"
-                    : undefined
+                readOnly
+                  ? `This request is ${initialRequest?.status} — it can no longer be edited or approved.`
+                  : !channel
+                    ? "Validate the bot channel first"
+                    : !teamName.trim()
+                      ? "Enter a team name"
+                      : undefined
               }
-              className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              className={
+                "rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60" +
+                (readOnly ? " blur-[1px]" : "")
+              }
             >
               {submitting
                 ? editing
@@ -885,8 +911,18 @@ export function OnboardingForm({
                     setSubmitting(false);
                   }
                 }}
-                disabled={submitting || !teamName.trim() || !channel}
-                className="rounded-md border border-border-medium px-4 py-2 text-sm font-medium text-default hover:bg-hover-light disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={
+                  readOnly || submitting || !teamName.trim() || !channel
+                }
+                title={
+                  readOnly
+                    ? `This request is ${initialRequest?.status} — it can no longer be edited.`
+                    : undefined
+                }
+                className={
+                  "rounded-md border border-border-medium px-4 py-2 text-sm font-medium text-default hover:bg-hover-light disabled:cursor-not-allowed disabled:opacity-60" +
+                  (readOnly ? " blur-[1px]" : "")
+                }
               >
                 Save changes
               </button>
@@ -903,7 +939,7 @@ export function OnboardingForm({
                 }
                 className="text-sm text-subtle hover:text-default"
               >
-                Cancel
+                {readOnly ? "Back" : "Cancel"}
               </button>
             )}
           </div>
@@ -925,14 +961,23 @@ export function OnboardingForm({
               key={r.id}
               className="mb-3 rounded-xl border border-border-medium bg-background-weak p-4 shadow-sm"
             >
-              <div className="flex items-center justify-between">
+              <div className="flex items-start justify-between gap-3">
                 <div className="text-sm font-medium text-default">
                   {r.payload.team_name} → #{r.payload.channel.channel_name}
                 </div>
-                <StatusBadge status={r.status} />
+                <div className="flex flex-col items-end gap-1">
+                  <StatusBadge status={r.status} />
+                  {statuses[r.id] && (
+                    <SourceStatusSummary sources={statuses[r.id].sources} />
+                  )}
+                </div>
               </div>
+              <OnboardingJourney
+                request={r}
+                sources={statuses[r.id]?.sources}
+              />
               {r.error_msg && (
-                <p className="mt-1 text-xs text-error">{r.error_msg}</p>
+                <p className="mt-2 text-xs text-error">{r.error_msg}</p>
               )}
               {r.decision_reason && (
                 <p className="mt-1 text-xs text-subtle">
@@ -965,17 +1010,23 @@ export function OnboardingForm({
                     Refresh scrape status
                   </button>
                   {statuses[r.id]?.sources.map((s) => (
-                    <div
-                      key={s.cc_pair_id}
-                      className="mt-1 flex items-center justify-between text-xs"
-                    >
-                      <span className="text-subtle">{s.name}</span>
-                      <span className="flex items-center gap-2">
-                        <StatusBadge status={s.status} /> {s.docs_indexed} docs
-                        {s.error_msg ? (
-                          <span className="text-error"> · {s.error_msg}</span>
-                        ) : null}
-                      </span>
+                    <div key={s.cc_pair_id} className="mt-1 text-xs">
+                      <div className="flex items-start gap-2">
+                        <span className="min-w-0 flex-1 text-subtle [overflow-wrap:anywhere]">
+                          {s.name}
+                        </span>
+                        <span className="w-24 shrink-0">
+                          <StatusBadge status={s.status} />
+                        </span>
+                        <span className="w-16 shrink-0 text-right text-subtle">
+                          {s.docs_indexed} docs
+                        </span>
+                      </div>
+                      {s.error_msg && (
+                        <p className="mt-0.5 [overflow-wrap:anywhere] text-error">
+                          {s.error_msg}
+                        </p>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -346,7 +346,7 @@ function Section({
   children: React.ReactNode;
 }) {
   return (
-    <section className="mb-5 rounded-xl border border-border-medium bg-background-weak p-5">
+    <section className="mb-5 rounded-xl border border-border-medium bg-background-weak p-5 shadow-sm">
       <div className="mb-4 flex items-baseline gap-3">
         <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent/10 text-xs font-semibold text-accent">
           {step}
@@ -700,7 +700,7 @@ export function OnboardingForm() {
           {mine.map((r) => (
             <div
               key={r.id}
-              className="mb-3 rounded-xl border border-border-medium bg-background-weak p-4"
+              className="mb-3 rounded-xl border border-border-medium bg-background-weak p-4 shadow-sm"
             >
               <div className="flex items-center justify-between">
                 <div className="text-sm font-medium text-default">

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -25,7 +25,7 @@ import {
   ClientCheck,
   SOURCE_CLIENT_CHECK,
 } from "@/lib/onboarding/clientChecks";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 // All colors come from the app's semantic theme tokens (text-default,
 // bg-background, border-border, …) so the page follows the global light/dark
@@ -198,6 +198,22 @@ const SOURCE_PLACEHOLDER: Record<OnboardingSourceType, string> = {
   jira: "project = ABC AND status != Done",
 };
 
+// Admin edit: rebuild the editable "additional sources" from a stored payload.
+// Drop the auto-added channel-history slack source (re-derived from the channel);
+// everything else (incl. docs) becomes an editable row.
+function prefillExtraSources(
+  sources: OnboardingSource[],
+  channelName: string
+): OnboardingSource[] {
+  return sources.filter(
+    (s) =>
+      !(
+        s.type === "slack" &&
+        (s.value === channelName || (s.label ?? "").endsWith(" history"))
+      )
+  );
+}
+
 function SourceRow({
   source,
   onChange,
@@ -329,43 +345,63 @@ function Section({
 
 // --- main form --------------------------------------------------------------
 
-export function OnboardingForm() {
+export function OnboardingForm({
+  initialRequest,
+}: {
+  // When set, the form runs in admin "edit a pending request" mode (prefilled).
+  initialRequest?: OnboardingRequestSnapshot;
+} = {}) {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const adminEdit = !!initialRequest;
+  const p = initialRequest?.payload;
+
   // "Submit a request" vs "My requests" — surfaced as top tabs so status isn't
   // buried at the bottom. Deep-linkable via ?view=requests (e.g. from the nav).
   const [tab, setTab] = useState<"form" | "requests">(
     searchParams?.get("view") === "requests" ? "requests" : "form"
   );
-  const [teamName, setTeamName] = useState("");
-  const [channelInput, setChannelInput] = useState("");
-  const [channel, setChannel] = useState<{ id: string; name: string } | null>(
-    null
+  const [teamName, setTeamName] = useState(p?.team_name ?? "");
+  const [channelInput, setChannelInput] = useState(
+    p?.channel?.channel_id ?? ""
   );
-  const [systemPrompt, setSystemPrompt] = useState("");
-  const [smeEnabled, setSmeEnabled] = useState(false);
-  const [smeGroup, setSmeGroup] = useState("");
-  const [oncallEnabled, setOncallEnabled] = useState(false);
-  const [oncallSchedule, setOncallSchedule] = useState("");
-  const [oncallHandles, setOncallHandles] = useState("");
+  const [channel, setChannel] = useState<{ id: string; name: string } | null>(
+    p ? { id: p.channel.channel_id, name: p.channel.channel_name } : null
+  );
+  const [systemPrompt, setSystemPrompt] = useState(p?.system_prompt ?? "");
+  const [smeEnabled, setSmeEnabled] = useState(p?.sme?.enabled ?? false);
+  const [smeGroup, setSmeGroup] = useState(p?.sme?.group_name ?? "");
+  const [oncallEnabled, setOncallEnabled] = useState(
+    p?.oncall?.enabled ?? false
+  );
+  const [oncallSchedule, setOncallSchedule] = useState(
+    p?.oncall?.schedule ?? ""
+  );
+  const [oncallHandles, setOncallHandles] = useState(p?.oncall?.handles ?? "");
 
   const [docsCloud, setDocsCloud] = useState("");
   const [docsOnprem, setDocsOnprem] = useState("");
-  const [extraSources, setExtraSources] = useState<OnboardingSource[]>([]);
+  const [extraSources, setExtraSources] = useState<OnboardingSource[]>(
+    p ? prefillExtraSources(p.sources, p.channel.channel_name) : []
+  );
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  const [savedNote, setSavedNote] = useState<string | null>(null);
   const [mine, setMine] = useState<OnboardingRequestSnapshot[]>([]);
   const [statuses, setStatuses] = useState<
     Record<number, OnboardingStatusResponse>
   >({});
 
   useEffect(() => {
+    if (adminEdit) return; // edit mode is fully prefilled from the request
     fetch("/api/onboarding/default-prompt")
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => d?.system_prompt && setSystemPrompt(d.system_prompt))
       .catch(() => {});
     void refreshMine();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function refreshMine(): Promise<OnboardingRequestSnapshot[]> {
@@ -394,7 +430,7 @@ export function OnboardingForm() {
   // (and re-poll every 15s) so the requester can see work happening without
   // clicking anything.
   useEffect(() => {
-    if (tab !== "requests") return;
+    if (adminEdit || tab !== "requests") return;
     let active = true;
     const load = async () => {
       const list = await refreshMine();
@@ -435,41 +471,96 @@ export function OnboardingForm() {
     return s;
   }
 
+  // Assemble the request payload from form state, or null if a required field
+  // is missing (sets the error message).
+  function buildPayload(): object | null {
+    if (!teamName.trim()) {
+      setError("Enter a team name.");
+      return null;
+    }
+    if (!channel) {
+      setError("Validate the bot channel first.");
+      return null;
+    }
+    const sources = buildSources();
+    if (sources.length === 0) {
+      setError("Add at least one source to index.");
+      return null;
+    }
+    return {
+      team_name: teamName.trim(),
+      channel: { channel_id: channel.id, channel_name: channel.name },
+      // Response format is standardized to citations for every channel.
+      response_type: "citations",
+      respond_tag_only: false,
+      system_prompt: systemPrompt,
+      task_prompt: "",
+      sme: { enabled: smeEnabled, group_name: smeGroup },
+      oncall: {
+        enabled: oncallEnabled,
+        schedule: oncallSchedule,
+        handles: oncallHandles,
+      },
+      sources,
+    };
+  }
+
+  async function errDetail(res: Response, fallback: string): Promise<string> {
+    return (await res.json().catch(() => null))?.detail || fallback;
+  }
+
+  // Admin edit: PATCH the pending request's payload (without approving).
+  async function saveEdits(): Promise<boolean> {
+    if (!initialRequest) return false;
+    setError(null);
+    setSavedNote(null);
+    const payload = buildPayload();
+    if (!payload) return false;
+    const res = await fetch(`/api/admin/onboarding/${initialRequest.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      setError(await errDetail(res, `Couldn't save changes (${res.status}).`));
+      return false;
+    }
+    return true;
+  }
+
   async function submit() {
     setError(null);
     setSubmitted(false);
-    if (!teamName.trim()) return setError("Enter a team name.");
-    if (!channel) return setError("Validate the bot channel first.");
-    const sources = buildSources();
-    if (sources.length === 0)
-      return setError("Add at least one source to index.");
+    setSavedNote(null);
+    const payload = buildPayload();
+    if (!payload) return;
 
     setSubmitting(true);
     try {
+      // Admin edit mode: save the edits, then approve + provision.
+      if (adminEdit && initialRequest) {
+        if (!(await saveEdits())) return;
+        const approve = await fetch(
+          `/api/admin/onboarding/${initialRequest.id}/approve`,
+          { method: "POST" }
+        );
+        if (!approve.ok) {
+          setError(await errDetail(approve, `Saved, but approve failed.`));
+          return;
+        }
+        router.push("/admin/onboarding");
+        return;
+      }
+
+      // Requester create mode.
       const res = await fetch("/api/onboarding", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          team_name: teamName.trim(),
-          channel: { channel_id: channel.id, channel_name: channel.name },
-          // Response format is standardized to citations for every channel.
-          response_type: "citations",
-          respond_tag_only: false,
-          system_prompt: systemPrompt,
-          task_prompt: "",
-          sme: { enabled: smeEnabled, group_name: smeGroup },
-          oncall: {
-            enabled: oncallEnabled,
-            schedule: oncallSchedule,
-            handles: oncallHandles,
-          },
-          sources,
-        }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) {
         setError(
-          (await res.json().catch(() => null))?.detail ||
-            `Couldn't submit the request (${res.status}).`
+          await errDetail(res, `Couldn't submit the request (${res.status}).`)
         );
         return;
       }
@@ -479,7 +570,7 @@ export function OnboardingForm() {
       setSubmitted(true);
       await refreshMine();
     } catch {
-      setError("Something went wrong submitting the request.");
+      setError("Something went wrong — please try again.");
     } finally {
       setSubmitting(false);
     }
@@ -489,38 +580,50 @@ export function OnboardingForm() {
     <div className="mx-auto max-w-3xl px-4 py-10">
       <header className="mb-8">
         <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
-          Team onboarding
+          {adminEdit ? "Review onboarding request" : "Team onboarding"}
         </p>
         <h1 className="text-2xl font-semibold text-default">
           Onboarding Darwin to Slack Channel
         </h1>
-        <p className="mt-2 text-sm text-subtle">
-          Point Darwin at your team&apos;s knowledge and channel. An admin
-          approves the request, then Darwin scrapes your sources and wires up
-          the assistant. Every field is checked live before you submit.
-        </p>
+        {adminEdit ? (
+          <p className="mt-2 text-sm text-subtle">
+            Submitted by{" "}
+            <span className="font-medium text-default">
+              {initialRequest?.requester_email}
+            </span>
+            . Fix any gaps below, then Save &amp; approve to provision.
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-subtle">
+            Point Darwin at your team&apos;s knowledge and channel. An admin
+            approves the request, then Darwin scrapes your sources and wires up
+            the assistant. Every field is checked live before you submit.
+          </p>
+        )}
       </header>
 
-      <div className="mb-6 flex gap-1 border-b border-border">
-        {(["form", "requests"] as const).map((t) => (
-          <button
-            key={t}
-            type="button"
-            onClick={() => setTab(t)}
-            className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-              tab === t
-                ? "border-accent text-default"
-                : "border-transparent text-subtle hover:text-default"
-            }`}
-          >
-            {t === "form"
-              ? "Submit a request"
-              : `My requests${mine.length ? ` (${mine.length})` : ""}`}
-          </button>
-        ))}
-      </div>
+      {!adminEdit && (
+        <div className="mb-6 flex gap-1 border-b border-border">
+          {(["form", "requests"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                tab === t
+                  ? "border-accent text-default"
+                  : "border-transparent text-subtle hover:text-default"
+              }`}
+            >
+              {t === "form"
+                ? "Submit a request"
+                : `My requests${mine.length ? ` (${mine.length})` : ""}`}
+            </button>
+          ))}
+        </div>
+      )}
 
-      {tab === "form" && (
+      {(adminEdit || tab === "form") && (
         <>
           <Section step={1} title="Channel & assistant">
             <ValidatedField
@@ -702,24 +805,67 @@ export function OnboardingForm() {
               Request submitted — an admin will review it. Track it below.
             </p>
           )}
-          <button
-            onClick={submit}
-            disabled={submitting || !teamName.trim() || !channel}
-            title={
-              !channel
-                ? "Validate the bot channel first"
-                : !teamName.trim()
-                  ? "Enter a team name"
-                  : undefined
-            }
-            className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {submitting ? "Submitting…" : "Submit onboarding request"}
-          </button>
+          {savedNote && !error && (
+            <p className="mb-3 flex items-center gap-1.5 text-sm text-link">
+              <FiCheck className="h-4 w-4 shrink-0" />
+              {savedNote}
+            </p>
+          )}
+          <div className="flex items-center gap-3">
+            <button
+              onClick={submit}
+              disabled={submitting || !teamName.trim() || !channel}
+              title={
+                !channel
+                  ? "Validate the bot channel first"
+                  : !teamName.trim()
+                    ? "Enter a team name"
+                    : undefined
+              }
+              className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting
+                ? adminEdit
+                  ? "Saving…"
+                  : "Submitting…"
+                : adminEdit
+                  ? "Save & approve"
+                  : "Submit onboarding request"}
+            </button>
+            {adminEdit && (
+              <button
+                type="button"
+                onClick={async () => {
+                  setSubmitting(true);
+                  try {
+                    if (await saveEdits())
+                      setSavedNote(
+                        "Changes saved. Still pending — approve when ready."
+                      );
+                  } finally {
+                    setSubmitting(false);
+                  }
+                }}
+                disabled={submitting || !teamName.trim() || !channel}
+                className="rounded-md border border-border-medium px-4 py-2 text-sm font-medium text-default hover:bg-hover-light disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Save changes
+              </button>
+            )}
+            {adminEdit && (
+              <button
+                type="button"
+                onClick={() => router.push("/admin/onboarding")}
+                className="text-sm text-subtle hover:text-default"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
         </>
       )}
 
-      {tab === "requests" && (
+      {!adminEdit && tab === "requests" && (
         <div>
           <h2 className="mb-3 text-lg font-semibold text-default">
             Your requests

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -556,12 +556,14 @@ export function OnboardingForm() {
           value={docsOnprem}
           onChange={setDocsOnprem}
           clientCheck={checkUrl}
+          helpText="Also accepts an automation-suite URL, e.g. https://docs.uipath.com/<product>/automation-suite/<latest-version>"
           optional
         />
         <p className="mb-4 text-xs text-subtle">
-          Paste the product root URL only — Darwin crawls every version
-          automatically. The bot channel&apos;s own message history is always
-          indexed.
+          Paste the product root URL only. For automation-suite docs the version
+          is stripped and Darwin scrapes the latest 3 versions automatically —
+          you don&apos;t need to list each version. The bot channel&apos;s own
+          message history is always indexed.
         </p>
 
         <div className="mb-2 text-sm font-medium text-default">

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -544,14 +544,14 @@ export function OnboardingForm() {
 
       <Section step={1} title="Channel & assistant">
         <ValidatedField
-          label="Bot channel link"
+          label="Slack Channel"
           placeholder="https://your-workspace.slack.com/archives/C0123ABCDE"
           kind="slack_channel"
           value={channelInput}
           onChange={setChannelInput}
           clientCheck={checkChannelLink}
           helpText="Get the link in Slack: open the channel → click ⋯ (More) → Copy → Copy link. A link lets us verify the exact channel; a name can't be checked reliably."
-          info="This is the channel where the Darwin Slack bot will be configured — it answers questions here."
+          info="This is the channel where the Darwin Slack bot answers questions. By default this channel is scraped and kept updated, so its knowledge stays current."
           onResolved={(r) =>
             setChannel(
               r.valid

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -21,6 +21,12 @@ import {
   ValidateKind,
   ValidationResult,
 } from "@/lib/onboarding/interfaces";
+import {
+  checkChannelLink,
+  checkUrl,
+  ClientCheck,
+  SOURCE_CLIENT_CHECK,
+} from "@/lib/onboarding/clientChecks";
 
 // All colors come from the app's semantic theme tokens (text-default,
 // bg-background, border-border, …) so the page follows the global light/dark
@@ -34,56 +40,6 @@ const inputClass =
 // How long to wait after the last keystroke before hitting the backend
 // validator (so you don't have to blur the field).
 const VALIDATE_DEBOUNCE_MS = 600;
-
-// --- lightweight, synchronous client-side format checks ---------------------
-// These catch obvious mistakes instantly (before any network round-trip) and
-// suppress the backend call until the format looks plausible. They return a
-// short hint string, or null when the value looks fine to send to the server.
-
-type ClientCheck = (value: string) => string | null;
-
-const checkChannel: ClientCheck = (v) => {
-  const raw = v.trim().replace(/^#/, "");
-  if (!raw) return null;
-  // A channel id or a pasted link/mention — let the server resolve it.
-  if (
-    /^C[A-Z0-9]{6,}$/.test(raw) ||
-    raw.includes("slack.com/") ||
-    raw.includes("<#")
-  )
-    return null;
-  if (/\s/.test(raw))
-    return "Channel names have no spaces — paste a link to be sure.";
-  if (/[A-Z]/.test(raw)) return "Channel names are lowercase.";
-  return null;
-};
-
-// The bot channel must be a link (a name can't be verified reliably). Accept a
-// channel link / <#…> mention / raw id; anything else prompts for the link.
-const checkChannelLink: ClientCheck = (v) => {
-  const raw = v.trim();
-  if (!raw) return null;
-  if (
-    /\/archives\/C[A-Z0-9]+/.test(raw) ||
-    /^<#C[A-Z0-9]+/.test(raw) ||
-    /^C[A-Z0-9]{6,}$/.test(raw)
-  )
-    return null;
-  return "Paste the channel link, not the name (steps below).";
-};
-
-const checkUrl: ClientCheck = (v) =>
-  /^https?:\/\//i.test(v.trim()) ? null : "Start with https://";
-
-const checkJql: ClientCheck = (v) =>
-  v.trim().length < 3 ? "Enter a JQL filter, e.g. project = ABC" : null;
-
-const SOURCE_CLIENT_CHECK: Record<OnboardingSourceType, ClientCheck> = {
-  web: checkUrl,
-  confluence: checkUrl,
-  slack: checkChannel,
-  jira: checkJql,
-};
 
 // --- light/dark toggle ------------------------------------------------------
 // Mirrors UserDropdown: flips `.dark` on <html> and persists to the same

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -6,9 +6,7 @@ import {
   FiChevronDown,
   FiChevronUp,
   FiInfo,
-  FiMoon,
   FiPlus,
-  FiSun,
   FiTrash2,
   FiX,
 } from "react-icons/fi";
@@ -40,39 +38,6 @@ const inputClass =
 // How long to wait after the last keystroke before hitting the backend
 // validator (so you don't have to blur the field).
 const VALIDATE_DEBOUNCE_MS = 600;
-
-// --- light/dark toggle ------------------------------------------------------
-// Mirrors UserDropdown: flips `.dark` on <html> and persists to the same
-// `darwin-theme` key, so the choice carries across the whole app. The page
-// already honors the global default set elsewhere — this just adds the control.
-
-function ThemeToggle() {
-  const [dark, setDark] = useState(true);
-  useEffect(() => {
-    setDark(document.documentElement.classList.contains("dark"));
-  }, []);
-  const toggle = () => {
-    const next = !dark;
-    setDark(next);
-    try {
-      localStorage.setItem("darwin-theme", next ? "dark" : "light");
-    } catch {
-      /* ignore */
-    }
-    document.documentElement.classList.toggle("dark", next);
-  };
-  return (
-    <button
-      type="button"
-      onClick={toggle}
-      title={dark ? "Switch to light mode" : "Switch to dark mode"}
-      aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
-      className="rounded-md border border-border-medium p-2 text-subtle hover:bg-hover-light hover:text-default"
-    >
-      {dark ? <FiSun className="h-4 w-4" /> : <FiMoon className="h-4 w-4" />}
-    </button>
-  );
-}
 
 // --- small info tooltip -----------------------------------------------------
 
@@ -486,21 +451,18 @@ export function OnboardingForm() {
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-10">
-      <header className="mb-8 flex items-start justify-between gap-4">
-        <div>
-          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
-            Team onboarding
-          </p>
-          <h1 className="text-2xl font-semibold text-default">
-            Onboarding Darwin to Slack Channel
-          </h1>
-          <p className="mt-2 text-sm text-subtle">
-            Point Darwin at your team&apos;s knowledge and channel. An admin
-            approves the request, then Darwin scrapes your sources and wires up
-            the assistant. Every field is checked live before you submit.
-          </p>
-        </div>
-        <ThemeToggle />
+      <header className="mb-8">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
+          Team onboarding
+        </p>
+        <h1 className="text-2xl font-semibold text-default">
+          Onboarding Darwin to Slack Channel
+        </h1>
+        <p className="mt-2 text-sm text-subtle">
+          Point Darwin at your team&apos;s knowledge and channel. An admin
+          approves the request, then Darwin scrapes your sources and wires up
+          the assistant. Every field is checked live before you submit.
+        </p>
       </header>
 
       <Section step={1} title="Channel & assistant">

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -25,6 +25,7 @@ import {
   ClientCheck,
   SOURCE_CLIENT_CHECK,
 } from "@/lib/onboarding/clientChecks";
+import { useSearchParams } from "next/navigation";
 
 // All colors come from the app's semantic theme tokens (text-default,
 // bg-background, border-border, …) so the page follows the global light/dark
@@ -329,6 +330,12 @@ function Section({
 // --- main form --------------------------------------------------------------
 
 export function OnboardingForm() {
+  const searchParams = useSearchParams();
+  // "Submit a request" vs "My requests" — surfaced as top tabs so status isn't
+  // buried at the bottom. Deep-linkable via ?view=requests (e.g. from the nav).
+  const [tab, setTab] = useState<"form" | "requests">(
+    searchParams?.get("view") === "requests" ? "requests" : "form"
+  );
   const [teamName, setTeamName] = useState("");
   const [channelInput, setChannelInput] = useState("");
   const [channel, setChannel] = useState<{ id: string; name: string } | null>(
@@ -361,13 +368,18 @@ export function OnboardingForm() {
     void refreshMine();
   }, []);
 
-  async function refreshMine() {
+  async function refreshMine(): Promise<OnboardingRequestSnapshot[]> {
     try {
       const r = await fetch("/api/onboarding/mine");
-      if (r.ok) setMine((await r.json()) as OnboardingRequestSnapshot[]);
+      if (r.ok) {
+        const data = (await r.json()) as OnboardingRequestSnapshot[];
+        setMine(data);
+        return data;
+      }
     } catch {
       /* ignore */
     }
+    return [];
   }
 
   async function loadStatus(id: number) {
@@ -377,6 +389,30 @@ export function OnboardingForm() {
       setStatuses((prev) => ({ ...prev, [id]: data }));
     }
   }
+
+  // On the "My requests" tab, auto-load each request's per-source scrape status
+  // (and re-poll every 15s) so the requester can see work happening without
+  // clicking anything.
+  useEffect(() => {
+    if (tab !== "requests") return;
+    let active = true;
+    const load = async () => {
+      const list = await refreshMine();
+      if (!active) return;
+      await Promise.all(
+        list
+          .filter((r) => (r.cc_pair_ids?.length ?? 0) > 0)
+          .map((r) => loadStatus(r.id))
+      );
+    };
+    void load();
+    const interval = setInterval(load, 15000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab]);
 
   function buildSources(): OnboardingSource[] {
     const s: OnboardingSource[] = [];
@@ -465,201 +501,234 @@ export function OnboardingForm() {
         </p>
       </header>
 
-      <Section step={1} title="Channel & assistant">
-        <ValidatedField
-          label="Slack Channel"
-          placeholder="https://your-workspace.slack.com/archives/C0123ABCDE"
-          kind="slack_channel"
-          value={channelInput}
-          onChange={setChannelInput}
-          clientCheck={checkChannelLink}
-          helpText="Get the link in Slack: open the channel → click ⋯ (More) → Copy → Copy link. A link lets us verify the exact channel; a name can't be checked reliably."
-          info="This is the channel where the Darwin Slack bot answers questions. By default this channel is scraped and kept updated, so its knowledge stays current."
-          onResolved={(r) =>
-            setChannel(
-              r.valid
-                ? {
-                    id: String(r.resolved.channel_id ?? ""),
-                    name: String(r.resolved.channel_name ?? ""),
-                  }
-                : null
-            )
-          }
-        />
-        <label className="mb-1 block text-sm font-medium text-default">
-          Team name
-        </label>
-        <input
-          value={teamName}
-          onChange={(e) => setTeamName(e.target.value)}
-          placeholder="e.g. Integration Service"
-          className={inputClass}
-        />
-      </Section>
-
-      <Section
-        step={2}
-        title="Sources"
-        hint="Add everything Darwin should read. Order sets retrieval priority — drag the arrows to reorder."
-      >
-        <ValidatedField
-          label="Docs-URL - Cloud"
-          placeholder="https://docs.uipath.com/<product>/automation-cloud/latest"
-          kind="docs"
-          value={docsCloud}
-          onChange={setDocsCloud}
-          clientCheck={checkUrl}
-          optional
-        />
-        <ValidatedField
-          label="Docs-URL - On-prem"
-          placeholder="https://docs.uipath.com/<product>/standalone/latest"
-          kind="docs"
-          value={docsOnprem}
-          onChange={setDocsOnprem}
-          clientCheck={checkUrl}
-          helpText="Also accepts an automation-suite URL, e.g. https://docs.uipath.com/<product>/automation-suite/<latest-version>"
-          optional
-        />
-        <p className="mb-4 text-xs text-subtle">
-          Paste the product root URL only. For automation-suite docs the version
-          is stripped and Darwin scrapes the latest 3 versions automatically —
-          you don&apos;t need to list each version.
-        </p>
-
-        <div className="mb-2 text-sm font-medium text-default">
-          Additional sources
-        </div>
-        {extraSources.map((s, i) => (
-          <SourceRow
-            key={i}
-            source={s}
-            canMoveUp={i > 0}
-            canMoveDown={i < extraSources.length - 1}
-            onChange={(ns) =>
-              setExtraSources((p) => p.map((x, j) => (j === i ? ns : x)))
-            }
-            onRemove={() => setExtraSources((p) => p.filter((_, j) => j !== i))}
-            onMove={(dir) =>
-              setExtraSources((p) => {
-                const j = i + dir;
-                if (j < 0 || j >= p.length) return p;
-                const c = [...p];
-                [c[i], c[j]] = [c[j], c[i]];
-                return c;
-              })
-            }
-          />
+      <div className="mb-6 flex gap-1 border-b border-border">
+        {(["form", "requests"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+              tab === t
+                ? "border-accent text-default"
+                : "border-transparent text-subtle hover:text-default"
+            }`}
+          >
+            {t === "form"
+              ? "Submit a request"
+              : `My requests${mine.length ? ` (${mine.length})` : ""}`}
+          </button>
         ))}
-        <button
-          type="button"
-          onClick={() =>
-            setExtraSources((p) => [...p, { type: "confluence", value: "" }])
-          }
-          className="mt-1 inline-flex items-center gap-1 text-sm text-link hover:underline"
-        >
-          <FiPlus className="h-4 w-4" /> Add source
-        </button>
-      </Section>
+      </div>
 
-      <Section
-        step={3}
-        title="Assistant prompt"
-        hint="Prefilled from the default (Orchestrator) — edit if your team needs different behavior."
-      >
-        <textarea
-          value={systemPrompt}
-          onChange={(e) => setSystemPrompt(e.target.value)}
-          rows={6}
-          className={`${inputClass} font-mono leading-relaxed`}
-        />
-      </Section>
-
-      <Section step={4} title="Options">
-        <label className="mb-3 flex items-center gap-2 text-sm text-default">
-          <input
-            type="checkbox"
-            checked={smeEnabled}
-            onChange={(e) => setSmeEnabled(e.target.checked)}
-            className="accent-accent"
-          />
-          Let SMEs verify answers
-        </label>
-        {smeEnabled && (
-          <ValidatedField
-            label="SME Slack user group(s)"
-            placeholder="e.g. as-smes (comma-separated)"
-            kind="slack_group"
-            value={smeGroup}
-            onChange={setSmeGroup}
-          />
-        )}
-        <label className="flex items-center gap-2 text-sm text-default">
-          <input
-            type="checkbox"
-            checked={oncallEnabled}
-            onChange={(e) => setOncallEnabled(e.target.checked)}
-            className="accent-accent"
-          />
-          On &quot;need more help&quot;, tag the on-call
-        </label>
-        {oncallEnabled && (
-          <div className="mt-3">
+      {tab === "form" && (
+        <>
+          <Section step={1} title="Channel & assistant">
             <ValidatedField
-              label="DRI Slack handle(s)"
-              placeholder="@as-dri (comma-separated for multiple)"
-              kind="slack_group"
-              value={oncallHandles}
-              onChange={setOncallHandles}
-              helpText="Slack user-group handle(s) to @-mention when someone needs more help, e.g. @as-dri."
-              optional
+              label="Slack Channel"
+              placeholder="https://your-workspace.slack.com/archives/C0123ABCDE"
+              kind="slack_channel"
+              value={channelInput}
+              onChange={setChannelInput}
+              clientCheck={checkChannelLink}
+              helpText="Get the link in Slack: open the channel → click ⋯ (More) → Copy → Copy link. A link lets us verify the exact channel; a name can't be checked reliably."
+              info="This is the channel where the Darwin Slack bot answers questions. By default this channel is scraped and kept updated, so its knowledge stays current."
+              onResolved={(r) =>
+                setChannel(
+                  r.valid
+                    ? {
+                        id: String(r.resolved.channel_id ?? ""),
+                        name: String(r.resolved.channel_name ?? ""),
+                      }
+                    : null
+                )
+              }
             />
+            <label className="mb-1 block text-sm font-medium text-default">
+              Team name
+            </label>
             <input
-              value={oncallSchedule}
-              onChange={(e) => setOncallSchedule(e.target.value)}
-              placeholder="OpsGenie schedule name (optional)"
+              value={teamName}
+              onChange={(e) => setTeamName(e.target.value)}
+              placeholder="e.g. Integration Service"
               className={inputClass}
             />
-            <p className="mt-1.5 text-xs text-subtle">
-              Optionally pull the current DRI from an OpsGenie schedule instead
-              of (or in addition to) the handles above.
+          </Section>
+
+          <Section
+            step={2}
+            title="Sources"
+            hint="Add everything Darwin should read. Order sets retrieval priority — drag the arrows to reorder."
+          >
+            <ValidatedField
+              label="Docs-URL - Cloud"
+              placeholder="https://docs.uipath.com/<product>/automation-cloud/latest"
+              kind="docs"
+              value={docsCloud}
+              onChange={setDocsCloud}
+              clientCheck={checkUrl}
+              optional
+            />
+            <ValidatedField
+              label="Docs-URL - On-prem"
+              placeholder="https://docs.uipath.com/<product>/standalone/latest"
+              kind="docs"
+              value={docsOnprem}
+              onChange={setDocsOnprem}
+              clientCheck={checkUrl}
+              helpText="Also accepts an automation-suite URL, e.g. https://docs.uipath.com/<product>/automation-suite/<latest-version>"
+              optional
+            />
+            <p className="mb-4 text-xs text-subtle">
+              Paste the product root URL only. For automation-suite docs the
+              version is stripped and Darwin scrapes the latest 3 versions
+              automatically — you don&apos;t need to list each version.
             </p>
-          </div>
-        )}
-      </Section>
 
-      {error && (
-        <p className="mb-3 flex items-center gap-1.5 text-sm text-error">
-          <FiX className="h-4 w-4 shrink-0" />
-          {error}
-        </p>
-      )}
-      {submitted && !error && (
-        <p className="mb-3 flex items-center gap-1.5 text-sm text-link">
-          <FiCheck className="h-4 w-4 shrink-0" />
-          Request submitted — an admin will review it. Track it below.
-        </p>
-      )}
-      <button
-        onClick={submit}
-        disabled={submitting || !teamName.trim() || !channel}
-        title={
-          !channel
-            ? "Validate the bot channel first"
-            : !teamName.trim()
-              ? "Enter a team name"
-              : undefined
-        }
-        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {submitting ? "Submitting…" : "Submit onboarding request"}
-      </button>
+            <div className="mb-2 text-sm font-medium text-default">
+              Additional sources
+            </div>
+            {extraSources.map((s, i) => (
+              <SourceRow
+                key={i}
+                source={s}
+                canMoveUp={i > 0}
+                canMoveDown={i < extraSources.length - 1}
+                onChange={(ns) =>
+                  setExtraSources((p) => p.map((x, j) => (j === i ? ns : x)))
+                }
+                onRemove={() =>
+                  setExtraSources((p) => p.filter((_, j) => j !== i))
+                }
+                onMove={(dir) =>
+                  setExtraSources((p) => {
+                    const j = i + dir;
+                    if (j < 0 || j >= p.length) return p;
+                    const c = [...p];
+                    [c[i], c[j]] = [c[j], c[i]];
+                    return c;
+                  })
+                }
+              />
+            ))}
+            <button
+              type="button"
+              onClick={() =>
+                setExtraSources((p) => [
+                  ...p,
+                  { type: "confluence", value: "" },
+                ])
+              }
+              className="mt-1 inline-flex items-center gap-1 text-sm text-link hover:underline"
+            >
+              <FiPlus className="h-4 w-4" /> Add source
+            </button>
+          </Section>
 
-      {mine.length > 0 && (
-        <div className="mt-12">
+          <Section
+            step={3}
+            title="Assistant prompt"
+            hint="Prefilled from the default (Orchestrator) — edit if your team needs different behavior."
+          >
+            <textarea
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+              rows={6}
+              className={`${inputClass} font-mono leading-relaxed`}
+            />
+          </Section>
+
+          <Section step={4} title="Options">
+            <label className="mb-3 flex items-center gap-2 text-sm text-default">
+              <input
+                type="checkbox"
+                checked={smeEnabled}
+                onChange={(e) => setSmeEnabled(e.target.checked)}
+                className="accent-accent"
+              />
+              Let SMEs verify answers
+            </label>
+            {smeEnabled && (
+              <ValidatedField
+                label="SME Slack user group(s)"
+                placeholder="e.g. as-smes (comma-separated)"
+                kind="slack_group"
+                value={smeGroup}
+                onChange={setSmeGroup}
+              />
+            )}
+            <label className="flex items-center gap-2 text-sm text-default">
+              <input
+                type="checkbox"
+                checked={oncallEnabled}
+                onChange={(e) => setOncallEnabled(e.target.checked)}
+                className="accent-accent"
+              />
+              On &quot;need more help&quot;, tag the on-call
+            </label>
+            {oncallEnabled && (
+              <div className="mt-3">
+                <ValidatedField
+                  label="DRI Slack handle(s)"
+                  placeholder="@as-dri (comma-separated for multiple)"
+                  kind="slack_group"
+                  value={oncallHandles}
+                  onChange={setOncallHandles}
+                  helpText="Slack user-group handle(s) to @-mention when someone needs more help, e.g. @as-dri."
+                  optional
+                />
+                <input
+                  value={oncallSchedule}
+                  onChange={(e) => setOncallSchedule(e.target.value)}
+                  placeholder="OpsGenie schedule name (optional)"
+                  className={inputClass}
+                />
+                <p className="mt-1.5 text-xs text-subtle">
+                  Optionally pull the current DRI from an OpsGenie schedule
+                  instead of (or in addition to) the handles above.
+                </p>
+              </div>
+            )}
+          </Section>
+
+          {error && (
+            <p className="mb-3 flex items-center gap-1.5 text-sm text-error">
+              <FiX className="h-4 w-4 shrink-0" />
+              {error}
+            </p>
+          )}
+          {submitted && !error && (
+            <p className="mb-3 flex items-center gap-1.5 text-sm text-link">
+              <FiCheck className="h-4 w-4 shrink-0" />
+              Request submitted — an admin will review it. Track it below.
+            </p>
+          )}
+          <button
+            onClick={submit}
+            disabled={submitting || !teamName.trim() || !channel}
+            title={
+              !channel
+                ? "Validate the bot channel first"
+                : !teamName.trim()
+                  ? "Enter a team name"
+                  : undefined
+            }
+            className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {submitting ? "Submitting…" : "Submit onboarding request"}
+          </button>
+        </>
+      )}
+
+      {tab === "requests" && (
+        <div>
           <h2 className="mb-3 text-lg font-semibold text-default">
             Your requests
           </h2>
+          {mine.length === 0 && (
+            <p className="text-sm text-subtle">
+              You haven&apos;t submitted any onboarding requests yet.
+            </p>
+          )}
           {mine.map((r) => (
             <div
               key={r.id}

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -58,6 +58,20 @@ const checkChannel: ClientCheck = (v) => {
   return null;
 };
 
+// The bot channel must be a link (a name can't be verified reliably). Accept a
+// channel link / <#…> mention / raw id; anything else prompts for the link.
+const checkChannelLink: ClientCheck = (v) => {
+  const raw = v.trim();
+  if (!raw) return null;
+  if (
+    /\/archives\/C[A-Z0-9]+/.test(raw) ||
+    /^<#C[A-Z0-9]+/.test(raw) ||
+    /^C[A-Z0-9]{6,}$/.test(raw)
+  )
+    return null;
+  return "Paste the channel link, not the name (steps below).";
+};
+
 const checkUrl: ClientCheck = (v) =>
   /^https?:\/\//i.test(v.trim()) ? null : "Start with https://";
 
@@ -159,6 +173,7 @@ function ValidatedField({
   optional,
   info,
   clientCheck,
+  helpText,
 }: {
   label: string;
   placeholder?: string;
@@ -169,6 +184,7 @@ function ValidatedField({
   optional?: boolean;
   info?: string;
   clientCheck?: ClientCheck;
+  helpText?: string;
 }) {
   const [result, setResult] = useState<ValidationResult | null>(null);
   const [checking, setChecking] = useState(false);
@@ -216,10 +232,11 @@ function ValidatedField({
         }}
         className={inputClass}
       />
+      {helpText && <p className="mt-1.5 text-xs text-subtle">{helpText}</p>}
       {checking && <p className="mt-1.5 text-xs text-subtle">Validating…</p>}
       {!checking && result && <ResultLine result={result} />}
       {!checking && !result && hint && (
-        <p className="mt-1.5 text-xs text-subtle">{hint}</p>
+        <p className="mt-1.5 text-xs text-error">{hint}</p>
       )}
     </div>
   );
@@ -527,12 +544,13 @@ export function OnboardingForm() {
 
       <Section step={1} title="Channel & assistant">
         <ValidatedField
-          label="Bot channel"
-          placeholder="#help-your-team or a channel link"
+          label="Bot channel link"
+          placeholder="https://your-workspace.slack.com/archives/C0123ABCDE"
           kind="slack_channel"
           value={channelInput}
           onChange={setChannelInput}
-          clientCheck={checkChannel}
+          clientCheck={checkChannelLink}
+          helpText="Get the link in Slack: open the channel → click ⋯ (More) → Copy → Copy link. A link lets us verify the exact channel; a name can't be checked reliably."
           info="This is the channel where the Darwin Slack bot will be configured — it answers questions here."
           onResolved={(r) =>
             setChannel(

--- a/web/src/app/onboarding/OnboardingForm.tsx
+++ b/web/src/app/onboarding/OnboardingForm.tsx
@@ -2,6 +2,15 @@
 
 import { useEffect, useState } from "react";
 import {
+  FiCheck,
+  FiChevronDown,
+  FiChevronUp,
+  FiInfo,
+  FiPlus,
+  FiTrash2,
+  FiX,
+} from "react-icons/fi";
+import {
   OnboardingRequestSnapshot,
   OnboardingSource,
   OnboardingSourceType,
@@ -10,6 +19,58 @@ import {
   ValidateKind,
   ValidationResult,
 } from "@/lib/onboarding/interfaces";
+
+// All colors come from the app's semantic theme tokens (text-default,
+// bg-background, border-border, …) so the page follows the global light/dark
+// setting automatically — no hardcoded colors anywhere.
+
+const inputClass =
+  "w-full rounded-md border border-border-medium bg-background px-3 py-2 " +
+  "text-sm text-default placeholder:text-subtle focus:outline-none " +
+  "focus:ring-2 focus:ring-accent/40 focus:border-accent";
+
+// --- small info tooltip -----------------------------------------------------
+
+function InfoHint({ text }: { text: string }) {
+  return (
+    <span className="group relative ml-1.5 inline-flex align-middle">
+      <FiInfo
+        className="h-3.5 w-3.5 cursor-help text-subtle"
+        aria-hidden
+        tabIndex={0}
+      />
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 top-6 z-20 w-60 -translate-x-1/2
+          rounded-md border border-border bg-background px-3 py-2 text-xs font-normal
+          leading-snug text-default opacity-0 shadow-lg transition-opacity duration-150
+          group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        {text}
+      </span>
+    </span>
+  );
+}
+
+// --- validation result line -------------------------------------------------
+
+function ResultLine({ result }: { result: ValidationResult | null }) {
+  if (!result) return null;
+  return (
+    <p
+      className={`mt-1.5 flex items-center gap-1 text-xs ${
+        result.valid ? "text-link" : "text-error"
+      }`}
+    >
+      {result.valid ? (
+        <FiCheck className="h-3.5 w-3.5 shrink-0" />
+      ) : (
+        <FiX className="h-3.5 w-3.5 shrink-0" />
+      )}
+      {result.message}
+    </p>
+  );
+}
 
 // --- inline-validated text field --------------------------------------------
 
@@ -21,6 +82,7 @@ function ValidatedField({
   onChange,
   onResolved,
   optional,
+  info,
 }: {
   label: string;
   placeholder?: string;
@@ -29,6 +91,7 @@ function ValidatedField({
   onChange: (v: string) => void;
   onResolved?: (r: ValidationResult) => void;
   optional?: boolean;
+  info?: string;
 }) {
   const [result, setResult] = useState<ValidationResult | null>(null);
   const [checking, setChecking] = useState(false);
@@ -46,12 +109,13 @@ function ValidatedField({
   }
 
   return (
-    <div className="mb-3">
-      <label className="block text-sm font-medium text-default mb-1">
+    <div className="mb-4">
+      <label className="mb-1 flex items-center text-sm font-medium text-default">
         {label}
         {optional && (
-          <span className="text-subtle font-normal"> (optional)</span>
+          <span className="ml-1 font-normal text-subtle">(optional)</span>
         )}
+        {info && <InfoHint text={info} />}
       </label>
       <input
         type="text"
@@ -62,19 +126,10 @@ function ValidatedField({
           setResult(null);
         }}
         onBlur={check}
-        className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm text-default focus:outline-none focus:ring-1 focus:ring-accent"
+        className={inputClass}
       />
-      {checking && <p className="mt-1 text-xs text-subtle">Validating…</p>}
-      {result && (
-        <p
-          className={`mt-1 text-xs ${
-            result.valid ? "text-link" : "text-error"
-          }`}
-        >
-          {result.valid ? "✓ " : "✗ "}
-          {result.message}
-        </p>
-      )}
+      {checking && <p className="mt-1.5 text-xs text-subtle">Validating…</p>}
+      <ResultLine result={result} />
     </div>
   );
 }
@@ -82,34 +137,52 @@ function ValidatedField({
 // --- status badge -----------------------------------------------------------
 
 function StatusBadge({ status }: { status: string }) {
-  const color =
+  const tone =
     status === "complete"
-      ? "text-link"
+      ? "bg-link/10 text-link"
       : status === "failed" || status === "rejected"
-        ? "text-error"
-        : "text-subtle";
-  return <span className={`text-xs font-semibold ${color}`}>{status}</span>;
+        ? "bg-error/10 text-error"
+        : "bg-accent/10 text-accent";
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-xs font-semibold capitalize ${tone}`}
+    >
+      {status}
+    </span>
+  );
 }
 
 // --- one extra source row ---------------------------------------------------
+
+const SOURCE_KIND: Record<OnboardingSourceType, ValidateKind> = {
+  web: "docs",
+  confluence: "confluence",
+  slack: "slack_channel",
+  jira: "jira",
+};
+
+const SOURCE_PLACEHOLDER: Record<OnboardingSourceType, string> = {
+  web: "https://docs.example.com/…",
+  confluence: "https://<org>.atlassian.net/wiki/spaces/KEY",
+  slack: "#another-channel",
+  jira: "project = ABC AND status != Done",
+};
 
 function SourceRow({
   source,
   onChange,
   onRemove,
   onMove,
+  canMoveUp,
+  canMoveDown,
 }: {
   source: OnboardingSource;
   onChange: (s: OnboardingSource) => void;
   onRemove: () => void;
   onMove: (dir: -1 | 1) => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
 }) {
-  const kindFor: Record<OnboardingSourceType, ValidateKind> = {
-    web: "docs",
-    confluence: "confluence",
-    github: "github", // live-validated: confirms the stored token can reach the repo
-    slack: "slack_channel",
-  };
   const [result, setResult] = useState<ValidationResult | null>(null);
   return (
     <div className="mb-2 flex items-start gap-2">
@@ -118,10 +191,10 @@ function SourceRow({
         onChange={(e) =>
           onChange({ ...source, type: e.target.value as OnboardingSourceType })
         }
-        className="rounded-md border border-border-medium bg-background-weak px-2 py-2 text-sm"
+        className="rounded-md border border-border-medium bg-background px-2 py-2 text-sm text-default focus:outline-none focus:ring-2 focus:ring-accent/40"
       >
         <option value="confluence">Confluence</option>
-        <option value="github">GitHub repo</option>
+        <option value="jira">Jira (filter)</option>
         <option value="slack">Slack channel</option>
         <option value="web">Web / docs</option>
       </select>
@@ -129,7 +202,7 @@ function SourceRow({
         <input
           type="text"
           value={source.value}
-          placeholder="URL, repo, or #channel"
+          placeholder={SOURCE_PLACEHOLDER[source.type]}
           onChange={(e) => {
             onChange({ ...source, value: e.target.value });
             setResult(null);
@@ -137,45 +210,74 @@ function SourceRow({
           onBlur={async () => {
             if (!source.value.trim()) return;
             setResult(
-              await validateOnboardingField(kindFor[source.type], source.value)
+              await validateOnboardingField(
+                SOURCE_KIND[source.type],
+                source.value
+              )
             );
           }}
-          className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm"
+          className={inputClass}
         />
-        {result && (
-          <p
-            className={`mt-1 text-xs ${result.valid ? "text-link" : "text-error"}`}
-          >
-            {result.valid ? "✓ " : "✗ "}
-            {result.message}
-          </p>
-        )}
+        <ResultLine result={result} />
       </div>
-      <button
-        type="button"
-        onClick={() => onMove(-1)}
-        title="Move up"
-        className="px-1 text-subtle hover:text-default"
-      >
-        ↑
-      </button>
-      <button
-        type="button"
-        onClick={() => onMove(1)}
-        title="Move down"
-        className="px-1 text-subtle hover:text-default"
-      >
-        ↓
-      </button>
-      <button
-        type="button"
-        onClick={onRemove}
-        title="Remove"
-        className="px-1 text-subtle hover:text-error"
-      >
-        ✕
-      </button>
+      <div className="flex shrink-0 items-center">
+        <button
+          type="button"
+          onClick={() => onMove(-1)}
+          disabled={!canMoveUp}
+          title="Higher priority"
+          className="p-1.5 text-subtle hover:text-default disabled:opacity-30"
+        >
+          <FiChevronUp className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onMove(1)}
+          disabled={!canMoveDown}
+          title="Lower priority"
+          className="p-1.5 text-subtle hover:text-default disabled:opacity-30"
+        >
+          <FiChevronDown className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={onRemove}
+          title="Remove source"
+          className="p-1.5 text-subtle hover:text-error"
+        >
+          <FiTrash2 className="h-4 w-4" />
+        </button>
+      </div>
     </div>
+  );
+}
+
+// --- section shell with a numbered step marker ------------------------------
+
+function Section({
+  step,
+  title,
+  hint,
+  children,
+}: {
+  step: number;
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-5 rounded-xl border border-border-medium bg-background-weak p-5">
+      <div className="mb-4 flex items-baseline gap-3">
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent/10 text-xs font-semibold text-accent">
+          {step}
+        </span>
+        <div>
+          <h2 className="text-sm font-semibold text-default">{title}</h2>
+          {hint && <p className="mt-0.5 text-xs text-subtle">{hint}</p>}
+        </div>
+      </div>
+      {children}
+    </section>
   );
 }
 
@@ -187,26 +289,19 @@ export function OnboardingForm() {
   const [channel, setChannel] = useState<{ id: string; name: string } | null>(
     null
   );
-  const [responseType, setResponseType] = useState<"citations" | "quotes">(
-    "citations"
-  );
-  const [respondTagOnly, setRespondTagOnly] = useState(false);
   const [systemPrompt, setSystemPrompt] = useState("");
   const [smeEnabled, setSmeEnabled] = useState(false);
   const [smeGroup, setSmeGroup] = useState("");
   const [oncallEnabled, setOncallEnabled] = useState(false);
   const [oncallSchedule, setOncallSchedule] = useState("");
-  const [jiraEnabled, setJiraEnabled] = useState(false);
-  const [jiraProject, setJiraProject] = useState("");
-  const [jiraIssueType, setJiraIssueType] = useState("");
 
   const [docsCloud, setDocsCloud] = useState("");
   const [docsOnprem, setDocsOnprem] = useState("");
-  const [includeHistory, setIncludeHistory] = useState(true);
   const [extraSources, setExtraSources] = useState<OnboardingSource[]>([]);
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
   const [mine, setMine] = useState<OnboardingRequestSnapshot[]>([]);
   const [statuses, setStatuses] = useState<
     Record<number, OnboardingStatusResponse>
@@ -247,7 +342,8 @@ export function OnboardingForm() {
         value: docsOnprem.trim(),
         label: "Docs (on-prem)",
       });
-    if (includeHistory && channel)
+    // The bot channel's message history is always indexed.
+    if (channel)
       s.push({
         type: "slack",
         value: channel.name,
@@ -259,10 +355,12 @@ export function OnboardingForm() {
 
   async function submit() {
     setError(null);
-    if (!teamName.trim()) return setError("Team name is required.");
+    setSubmitted(false);
+    if (!teamName.trim()) return setError("Enter a team name.");
     if (!channel) return setError("Validate the bot channel first.");
     const sources = buildSources();
-    if (sources.length === 0) return setError("Add at least one source.");
+    if (sources.length === 0)
+      return setError("Add at least one source to index.");
 
     setSubmitting(true);
     try {
@@ -272,32 +370,27 @@ export function OnboardingForm() {
         body: JSON.stringify({
           team_name: teamName.trim(),
           channel: { channel_id: channel.id, channel_name: channel.name },
-          response_type: responseType,
-          respond_tag_only: respondTagOnly,
+          // Response format is standardized to citations for every channel.
+          response_type: "citations",
+          respond_tag_only: false,
           system_prompt: systemPrompt,
           task_prompt: "",
           sme: { enabled: smeEnabled, group_name: smeGroup },
           oncall: { enabled: oncallEnabled, schedule: oncallSchedule },
-          jira: {
-            enabled: jiraEnabled,
-            project_key: jiraProject,
-            issue_type: jiraIssueType,
-            component: "",
-          },
           sources,
         }),
       });
       if (!res.ok) {
         setError(
           (await res.json().catch(() => null))?.detail ||
-            `Submit failed (${res.status}).`
+            `Couldn't submit the request (${res.status}).`
         );
         return;
       }
-      // reset the source fields; keep it simple.
       setDocsCloud("");
       setDocsOnprem("");
       setExtraSources([]);
+      setSubmitted(true);
       await refreshMine();
     } catch {
       setError("Something went wrong submitting the request.");
@@ -306,26 +399,30 @@ export function OnboardingForm() {
     }
   }
 
-  const section =
-    "mb-6 rounded-lg border border-border-medium bg-background-weak p-4";
-
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <h1 className="text-2xl font-semibold text-default mb-1">
-        Onboard a team to Darwin
-      </h1>
-      <p className="text-sm text-subtle mb-6">
-        Submit this request; an admin approves it, then Darwin auto-scrapes your
-        sources and wires up your assistant. Every field is validated live.
-      </p>
+    <div className="mx-auto max-w-3xl px-4 py-10">
+      <header className="mb-8">
+        <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-accent">
+          Team onboarding
+        </p>
+        <h1 className="text-2xl font-semibold text-default">
+          Onboarding Darwin to Slack Channel
+        </h1>
+        <p className="mt-2 text-sm text-subtle">
+          Point Darwin at your team&apos;s knowledge and channel. An admin
+          approves the request, then Darwin scrapes your sources and wires up
+          the assistant. Every field is checked live before you submit.
+        </p>
+      </header>
 
-      <div className={section}>
+      <Section step={1} title="Channel & assistant">
         <ValidatedField
           label="Bot channel"
           placeholder="#help-your-team or a channel link"
           kind="slack_channel"
           value={channelInput}
           onChange={setChannelInput}
+          info="This is the channel where the Darwin Slack bot will be configured — it answers questions here."
           onResolved={(r) =>
             setChannel(
               r.valid
@@ -337,46 +434,24 @@ export function OnboardingForm() {
             )
           }
         />
-        <label className="block text-sm font-medium text-default mb-1 mt-2">
+        <label className="mb-1 block text-sm font-medium text-default">
           Team name
         </label>
         <input
           value={teamName}
           onChange={(e) => setTeamName(e.target.value)}
           placeholder="e.g. Integration Service"
-          className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm mb-3"
+          className={inputClass}
         />
-        <div className="flex items-center gap-4">
-          <label className="text-sm text-default">
-            Response format:{" "}
-            <select
-              value={responseType}
-              onChange={(e) =>
-                setResponseType(e.target.value as "citations" | "quotes")
-              }
-              className="rounded-md border border-border-medium bg-background-weak px-2 py-1 text-sm"
-            >
-              <option value="citations">Citations</option>
-              <option value="quotes">Quotes</option>
-            </select>
-          </label>
-          <label className="flex items-center gap-2 text-sm text-default">
-            <input
-              type="checkbox"
-              checked={respondTagOnly}
-              onChange={(e) => setRespondTagOnly(e.target.checked)}
-            />
-            Respond only when tagged
-          </label>
-        </div>
-      </div>
+      </Section>
 
-      <div className={section}>
-        <h2 className="text-sm font-semibold text-default mb-2">
-          Sources (priority order)
-        </h2>
+      <Section
+        step={2}
+        title="Sources"
+        hint="Add everything Darwin should read. Order sets retrieval priority — drag the arrows to reorder."
+      >
         <ValidatedField
-          label="Documentation — Cloud (root URL)"
+          label="Docs-URL - Cloud"
           placeholder="https://docs.uipath.com/<product>/automation-cloud/latest"
           kind="docs"
           value={docsCloud}
@@ -384,32 +459,28 @@ export function OnboardingForm() {
           optional
         />
         <ValidatedField
-          label="Documentation — On-prem / standalone (root URL)"
+          label="Docs-URL - On-prem"
           placeholder="https://docs.uipath.com/<product>/standalone/latest"
           kind="docs"
           value={docsOnprem}
           onChange={setDocsOnprem}
           optional
         />
-        <p className="text-xs text-subtle mb-3">
-          Paste the product root URL only — Darwin crawls all versions
-          automatically.
+        <p className="mb-4 text-xs text-subtle">
+          Paste the product root URL only — Darwin crawls every version
+          automatically. The bot channel&apos;s own message history is always
+          indexed.
         </p>
-        <label className="flex items-center gap-2 text-sm text-default mb-3">
-          <input
-            type="checkbox"
-            checked={includeHistory}
-            onChange={(e) => setIncludeHistory(e.target.checked)}
-          />
-          Include this channel&apos;s message history
-        </label>
-        <div className="text-sm font-medium text-default mb-1">
+
+        <div className="mb-2 text-sm font-medium text-default">
           Additional sources
         </div>
         {extraSources.map((s, i) => (
           <SourceRow
             key={i}
             source={s}
+            canMoveUp={i > 0}
+            canMoveDown={i < extraSources.length - 1}
             onChange={(ns) =>
               setExtraSources((p) => p.map((x, j) => (j === i ? ns : x)))
             }
@@ -430,34 +501,32 @@ export function OnboardingForm() {
           onClick={() =>
             setExtraSources((p) => [...p, { type: "confluence", value: "" }])
           }
-          className="mt-1 text-sm text-link hover:underline"
+          className="mt-1 inline-flex items-center gap-1 text-sm text-link hover:underline"
         >
-          + Add source
+          <FiPlus className="h-4 w-4" /> Add source
         </button>
-      </div>
+      </Section>
 
-      <div className={section}>
-        <label className="block text-sm font-medium text-default mb-1">
-          System prompt
-        </label>
-        <p className="text-xs text-subtle mb-1">
-          Prefilled from the default (Orchestrator) — edit as needed.
-        </p>
+      <Section
+        step={3}
+        title="Assistant prompt"
+        hint="Prefilled from the default (Orchestrator) — edit if your team needs different behavior."
+      >
         <textarea
           value={systemPrompt}
           onChange={(e) => setSystemPrompt(e.target.value)}
-          rows={5}
-          className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm font-mono"
+          rows={6}
+          className={`${inputClass} font-mono leading-relaxed`}
         />
-      </div>
+      </Section>
 
-      <div className={section}>
-        <h2 className="text-sm font-semibold text-default mb-2">Options</h2>
-        <label className="flex items-center gap-2 text-sm text-default mb-2">
+      <Section step={4} title="Options">
+        <label className="mb-3 flex items-center gap-2 text-sm text-default">
           <input
             type="checkbox"
             checked={smeEnabled}
             onChange={(e) => setSmeEnabled(e.target.checked)}
+            className="accent-accent"
           />
           Let SMEs verify answers
         </label>
@@ -470,11 +539,12 @@ export function OnboardingForm() {
             onChange={setSmeGroup}
           />
         )}
-        <label className="flex items-center gap-2 text-sm text-default mb-2">
+        <label className="flex items-center gap-2 text-sm text-default">
           <input
             type="checkbox"
             checked={oncallEnabled}
             onChange={(e) => setOncallEnabled(e.target.checked)}
+            className="accent-accent"
           />
           On &quot;need more help&quot;, tag the on-call
         </label>
@@ -483,53 +553,40 @@ export function OnboardingForm() {
             value={oncallSchedule}
             onChange={(e) => setOncallSchedule(e.target.value)}
             placeholder="Opsgenie schedule name"
-            className="w-full rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm mb-3"
+            className={`${inputClass} mt-3`}
           />
         )}
-        <label className="flex items-center gap-2 text-sm text-default mb-2">
-          <input
-            type="checkbox"
-            checked={jiraEnabled}
-            onChange={(e) => setJiraEnabled(e.target.checked)}
-          />
-          Enable Jira ticket creation
-        </label>
-        {jiraEnabled && (
-          <div className="flex gap-2">
-            <input
-              value={jiraProject}
-              onChange={(e) => setJiraProject(e.target.value)}
-              placeholder="Project key"
-              className="flex-1 rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm"
-            />
-            <input
-              value={jiraIssueType}
-              onChange={(e) => setJiraIssueType(e.target.value)}
-              placeholder="Issue type"
-              className="flex-1 rounded-md border border-border-medium bg-background-weak px-3 py-2 text-sm"
-            />
-          </div>
-        )}
-      </div>
+      </Section>
 
-      {error && <p className="mb-3 text-sm text-error">{error}</p>}
+      {error && (
+        <p className="mb-3 flex items-center gap-1.5 text-sm text-error">
+          <FiX className="h-4 w-4 shrink-0" />
+          {error}
+        </p>
+      )}
+      {submitted && !error && (
+        <p className="mb-3 flex items-center gap-1.5 text-sm text-link">
+          <FiCheck className="h-4 w-4 shrink-0" />
+          Request submitted — an admin will review it. Track it below.
+        </p>
+      )}
       <button
         onClick={submit}
         disabled={submitting}
-        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted disabled:opacity-60"
+        className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-inverted transition-opacity hover:opacity-90 disabled:opacity-60"
       >
         {submitting ? "Submitting…" : "Submit onboarding request"}
       </button>
 
       {mine.length > 0 && (
-        <div className="mt-10">
-          <h2 className="text-lg font-semibold text-default mb-3">
+        <div className="mt-12">
+          <h2 className="mb-3 text-lg font-semibold text-default">
             Your requests
           </h2>
           {mine.map((r) => (
             <div
               key={r.id}
-              className="mb-3 rounded-lg border border-border-medium p-3"
+              className="mb-3 rounded-xl border border-border-medium bg-background-weak p-4"
             >
               <div className="flex items-center justify-between">
                 <div className="text-sm font-medium text-default">
@@ -559,9 +616,8 @@ export function OnboardingForm() {
                       className="mt-1 flex items-center justify-between text-xs"
                     >
                       <span className="text-subtle">{s.name}</span>
-                      <span>
-                        <StatusBadge status={s.status} /> · {s.docs_indexed}{" "}
-                        docs
+                      <span className="flex items-center gap-2">
+                        <StatusBadge status={s.status} /> {s.docs_indexed} docs
                         {s.error_msg ? (
                           <span className="text-error"> · {s.error_msg}</span>
                         ) : null}

--- a/web/src/app/onboarding/OnboardingJourney.tsx
+++ b/web/src/app/onboarding/OnboardingJourney.tsx
@@ -1,0 +1,178 @@
+import Link from "next/link";
+import { FiCheck, FiX } from "react-icons/fi";
+import {
+  countSourceStatuses,
+  OnboardingRequestSnapshot,
+  SourceStatus,
+} from "@/lib/onboarding/interfaces";
+
+// Visual "light-up" journey for an onboarding request: the milestones from
+// submission through the assistant going live in Slack, each derived from real
+// request state (status + the FK ids finalize sets), so an admin can see at a
+// glance how far along a request is and where it stalled if it did.
+//
+// Milestones after indexing (document set / assistant / Slack bot) are written
+// together by the finalizer, so they normally flip done in one step — showing
+// them separately still communicates the pipeline and pinpoints a partial
+// finalize failure.
+
+type StepState = "done" | "current" | "failed" | "pending";
+
+function Node({ state }: { state: StepState }) {
+  const base =
+    "flex h-6 w-6 items-center justify-center rounded-full text-xs shrink-0";
+  if (state === "done") {
+    return (
+      <span className={`${base} bg-link text-inverted`}>
+        <FiCheck className="h-3.5 w-3.5" />
+      </span>
+    );
+  }
+  if (state === "failed") {
+    return (
+      <span className={`${base} bg-error text-inverted`}>
+        <FiX className="h-3.5 w-3.5" />
+      </span>
+    );
+  }
+  if (state === "current") {
+    return (
+      <span className={`${base} border-2 border-accent`}>
+        <span className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+      </span>
+    );
+  }
+  return <span className={`${base} border border-border-medium`} />;
+}
+
+function labelTone(state: StepState): string {
+  if (state === "done") return "text-default";
+  if (state === "current") return "text-accent font-medium";
+  if (state === "failed") return "text-error font-medium";
+  return "text-subtle";
+}
+
+export function OnboardingJourney({
+  request,
+  sources,
+  admin = false,
+}: {
+  request: OnboardingRequestSnapshot;
+  sources?: SourceStatus[];
+  // Admin view: linkify the created artifacts (document set / assistant / Slack
+  // bot) to their admin pages. Those routes are admin-only, so the requester
+  // view leaves them as plain labels (the "Live" → chat link works for both).
+  admin?: boolean;
+}) {
+  // Rejected / cancelled requests never enter the light-up pipeline.
+  if (request.status === "rejected" || request.status === "cancelled") {
+    return null;
+  }
+
+  const counts =
+    sources && sources.length ? countSourceStatuses(sources) : null;
+  const s = request.status;
+  const indexedDone =
+    request.document_set_id != null ||
+    s === "complete" ||
+    (!!counts && counts.total > 0 && counts.succeeded === counts.total);
+
+  // Each artifact gets a link only once its id exists ("as and when available").
+  const docId = request.document_set_id;
+  const personaId = request.persona_id;
+  const cfgId = request.slack_bot_config_id;
+
+  const raw: {
+    label: string;
+    done: boolean;
+    detail?: string;
+    href?: string;
+  }[] = [
+    { label: "Submitted", done: true },
+    { label: "Approved", done: s !== "pending" },
+    {
+      label: "Sources indexed",
+      done: indexedDone,
+      detail: counts ? `${counts.succeeded}/${counts.total}` : undefined,
+    },
+    {
+      label: "Document set",
+      done: docId != null,
+      href:
+        admin && docId != null ? `/admin/documents/sets/${docId}` : undefined,
+    },
+    {
+      label: "Assistant",
+      done: personaId != null,
+      href:
+        admin && personaId != null
+          ? `/admin/assistants/${personaId}`
+          : undefined,
+    },
+    {
+      label: "Slack bot",
+      done: cfgId != null,
+      href: admin && cfgId != null ? `/admin/bot/${cfgId}` : undefined,
+    },
+    {
+      label: "Live",
+      done: s === "complete",
+      // Open the finished assistant in chat — useful to admin and requester.
+      href:
+        s === "complete" && personaId != null
+          ? `/chat?assistantId=${personaId}`
+          : undefined,
+    },
+  ];
+
+  // The first not-yet-done step is where we are now — "current" while work is
+  // ongoing, "failed" if the request has failed at this point.
+  const firstPending = raw.findIndex((r) => !r.done);
+  const steps = raw.map((r, i) => {
+    let state: StepState;
+    if (r.done) state = "done";
+    else if (i === firstPending) state = s === "failed" ? "failed" : "current";
+    else state = "pending";
+    return { ...r, state };
+  });
+
+  return (
+    <ol className="mt-3 flex flex-wrap items-start gap-y-3">
+      {steps.map((step, i) => (
+        <li key={step.label} className="flex items-start">
+          <div className="flex w-16 flex-col items-center text-center">
+            <Node state={step.state} />
+            {step.href ? (
+              <Link
+                href={step.href}
+                className={`mt-1 text-[10px] leading-tight underline-offset-2 hover:underline ${labelTone(
+                  step.state
+                )}`}
+              >
+                {step.label}
+              </Link>
+            ) : (
+              <span
+                className={`mt-1 text-[10px] leading-tight ${labelTone(
+                  step.state
+                )}`}
+              >
+                {step.label}
+              </span>
+            )}
+            {step.detail && (
+              <span className="text-[10px] text-subtle">{step.detail}</span>
+            )}
+          </div>
+          {i < steps.length - 1 && (
+            <span
+              className={`mt-3 h-px w-4 shrink-0 ${
+                step.state === "done" ? "bg-link" : "bg-border-medium"
+              }`}
+            />
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web/src/app/onboarding/SourceStatusSummary.tsx
+++ b/web/src/app/onboarding/SourceStatusSummary.tsx
@@ -1,0 +1,24 @@
+import { countSourceStatuses, SourceStatus } from "@/lib/onboarding/interfaces";
+
+// One-line rollup of a request's per-source scrape status, e.g.
+// "4/6 succeeded · 1 indexing · 1 failed". Shown above the per-source rows so
+// admins/requesters see overall progress at a glance instead of scanning each
+// row (and so an in-flight request doesn't read as simply "failed").
+export function SourceStatusSummary({ sources }: { sources: SourceStatus[] }) {
+  if (!sources.length) return null;
+  const c = countSourceStatuses(sources);
+  return (
+    <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">
+      <span className="font-semibold text-default">
+        {c.succeeded}/{c.total} succeeded
+      </span>
+      {c.indexing > 0 && (
+        <span className="text-accent">· {c.indexing} indexing</span>
+      )}
+      {c.pending > 0 && (
+        <span className="text-subtle">· {c.pending} pending</span>
+      )}
+      {c.failed > 0 && <span className="text-error">· {c.failed} failed</span>}
+    </div>
+  );
+}

--- a/web/src/app/onboarding/[id]/edit/page.tsx
+++ b/web/src/app/onboarding/[id]/edit/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { OnboardingForm } from "@/app/onboarding/OnboardingForm";
+import { OnboardingRequestSnapshot } from "@/lib/onboarding/interfaces";
+
+// The requester opens their own still-pending request in the shared onboarding
+// form (prefilled) to fix details before an admin reviews it. The backend PATCH
+// enforces owner-or-admin + pending-only; SSO is enforced by the /onboarding
+// page above and the API. Ownership scoping is server-side, so a non-owner just
+// gets a 403 on load here.
+export default function Page({ params }: { params: { id: string } }) {
+  const [request, setRequest] = useState<OnboardingRequestSnapshot | null>(
+    null
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/onboarding/${params.id}`)
+      .then(async (r) => {
+        if (!r.ok) {
+          setError(
+            r.status === 403 || r.status === 404
+              ? "This request can't be edited (it may no longer be pending)."
+              : `Couldn't load request (${r.status}).`
+          );
+          return;
+        }
+        setRequest((await r.json()) as OnboardingRequestSnapshot);
+      })
+      .catch(() => setError("Couldn't load request."));
+  }, [params.id]);
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 text-sm text-error">
+        {error}
+      </div>
+    );
+  }
+  if (!request) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 text-sm text-subtle">
+        Loading…
+      </div>
+    );
+  }
+  return (
+    // Suspense: OnboardingForm reads useSearchParams; provide the boundary the
+    // prod build requires.
+    <Suspense fallback={null}>
+      <OnboardingForm initialRequest={request} editMode="requester" />
+    </Suspense>
+  );
+}

--- a/web/src/app/onboarding/layout.tsx
+++ b/web/src/app/onboarding/layout.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation";
+import { getAuthTypeMetadataSS, getCurrentUserSS } from "@/lib/userSS";
+import { Header } from "@/components/header/Header";
+
+// Shared chrome + SSO gate for every /onboarding route (the submit/requests
+// form and the requester edit sub-route). Mirrors the rest of the app: signed-
+// out users go to login rather than seeing a form whose every action 401s. The
+// backend endpoints enforce auth regardless — this is the matching frontend
+// gate + defense-in-depth. Rendering the standard Header here gives users the
+// logo (back to chat) and user menu (Admin Panel + theme toggle for admins).
+export default async function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [authTypeMetadata, user] = await Promise.all([
+    getAuthTypeMetadataSS(),
+    getCurrentUserSS(),
+  ]);
+
+  const authDisabled = authTypeMetadata?.authType === "disabled";
+  if (!authDisabled && !user) {
+    return redirect("/auth/login?next=/onboarding");
+  }
+  if (user && !user.is_verified && authTypeMetadata?.requiresVerification) {
+    return redirect("/auth/waiting-on-verification");
+  }
+
+  return (
+    <div className="h-screen overflow-y-auto bg-background">
+      <Header user={user} />
+      {children}
+    </div>
+  );
+}

--- a/web/src/app/onboarding/page.tsx
+++ b/web/src/app/onboarding/page.tsx
@@ -1,5 +1,24 @@
+import { redirect } from "next/navigation";
+import { getAuthTypeMetadataSS, getCurrentUserSS } from "@/lib/userSS";
 import { OnboardingForm } from "./OnboardingForm";
 
-export default function Page() {
+// Require an authenticated (SSO) session, mirroring the rest of the app: send
+// signed-out users to the login flow rather than rendering a form whose every
+// action would 401. The backend endpoints enforce auth regardless — this is the
+// matching frontend gate + defense-in-depth.
+export default async function Page() {
+  const [authTypeMetadata, user] = await Promise.all([
+    getAuthTypeMetadataSS(),
+    getCurrentUserSS(),
+  ]);
+
+  const authDisabled = authTypeMetadata?.authType === "disabled";
+  if (!authDisabled && !user) {
+    return redirect("/auth/login?next=/onboarding");
+  }
+  if (user && !user.is_verified && authTypeMetadata?.requiresVerification) {
+    return redirect("/auth/waiting-on-verification");
+  }
+
   return <OnboardingForm />;
 }

--- a/web/src/app/onboarding/page.tsx
+++ b/web/src/app/onboarding/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { getAuthTypeMetadataSS, getCurrentUserSS } from "@/lib/userSS";
 import { Header } from "@/components/header/Header";
@@ -26,7 +27,11 @@ export default async function Page() {
   return (
     <div className="h-screen overflow-y-auto bg-background">
       <Header user={user} />
-      <OnboardingForm />
+      {/* Suspense: OnboardingForm reads useSearchParams (?view=requests deep
+          link), which the prod build requires be wrapped. */}
+      <Suspense fallback={null}>
+        <OnboardingForm />
+      </Suspense>
     </div>
   );
 }

--- a/web/src/app/onboarding/page.tsx
+++ b/web/src/app/onboarding/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getAuthTypeMetadataSS, getCurrentUserSS } from "@/lib/userSS";
+import { Header } from "@/components/header/Header";
 import { OnboardingForm } from "./OnboardingForm";
 
 // Require an authenticated (SSO) session, mirroring the rest of the app: send
@@ -20,5 +21,12 @@ export default async function Page() {
     return redirect("/auth/waiting-on-verification");
   }
 
-  return <OnboardingForm />;
+  // Render the standard app header so users get the logo (back to chat) and the
+  // user menu — which, for admins, includes the Admin Panel link + theme toggle.
+  return (
+    <div className="h-screen overflow-y-auto bg-background">
+      <Header user={user} />
+      <OnboardingForm />
+    </div>
+  );
 }

--- a/web/src/app/onboarding/page.tsx
+++ b/web/src/app/onboarding/page.tsx
@@ -1,0 +1,5 @@
+import { OnboardingForm } from "./OnboardingForm";
+
+export default function Page() {
+  return <OnboardingForm />;
+}

--- a/web/src/app/onboarding/page.tsx
+++ b/web/src/app/onboarding/page.tsx
@@ -1,37 +1,13 @@
 import { Suspense } from "react";
-import { redirect } from "next/navigation";
-import { getAuthTypeMetadataSS, getCurrentUserSS } from "@/lib/userSS";
-import { Header } from "@/components/header/Header";
 import { OnboardingForm } from "./OnboardingForm";
 
-// Require an authenticated (SSO) session, mirroring the rest of the app: send
-// signed-out users to the login flow rather than rendering a form whose every
-// action would 401. The backend endpoints enforce auth regardless — this is the
-// matching frontend gate + defense-in-depth.
-export default async function Page() {
-  const [authTypeMetadata, user] = await Promise.all([
-    getAuthTypeMetadataSS(),
-    getCurrentUserSS(),
-  ]);
-
-  const authDisabled = authTypeMetadata?.authType === "disabled";
-  if (!authDisabled && !user) {
-    return redirect("/auth/login?next=/onboarding");
-  }
-  if (user && !user.is_verified && authTypeMetadata?.requiresVerification) {
-    return redirect("/auth/waiting-on-verification");
-  }
-
-  // Render the standard app header so users get the logo (back to chat) and the
-  // user menu — which, for admins, includes the Admin Panel link + theme toggle.
+// SSO gate + app header live in ./layout.tsx (shared with the edit sub-route).
+export default function Page() {
+  // Suspense: OnboardingForm reads useSearchParams (?view=requests deep link),
+  // which the prod build requires be wrapped.
   return (
-    <div className="h-screen overflow-y-auto bg-background">
-      <Header user={user} />
-      {/* Suspense: OnboardingForm reads useSearchParams (?view=requests deep
-          link), which the prod build requires be wrapped. */}
-      <Suspense fallback={null}>
-        <OnboardingForm />
-      </Suspense>
-    </div>
+    <Suspense fallback={null}>
+      <OnboardingForm />
+    </Suspense>
   );
 }

--- a/web/src/components/admin/Layout.tsx
+++ b/web/src/components/admin/Layout.tsx
@@ -33,6 +33,7 @@ import {
   FiShield,
   FiSlack,
   FiTool,
+  FiUserPlus,
 } from "react-icons/fi";
 
 export async function Layout({ children }: { children: React.ReactNode }) {
@@ -75,264 +76,273 @@ export async function Layout({ children }: { children: React.ReactNode }) {
           {/* Suspense: AdminSidebar uses useSearchParams (for active-tab
               highlighting), which the prod build requires be wrapped. */}
           <Suspense fallback={<div className="w-48" />}>
-          <AdminSidebar
-            collections={[
-              {
-                name: "Connectors",
-                items: [
-                  {
-                    name: (
-                      <div className="flex">
-                        <NotebookIcon size={18} />
-                        <div className="ml-1">Existing Connectors</div>
-                      </div>
-                    ),
-                    link: "/admin/indexing/status",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <BarChartIcon size={18} />
-                        <div className="ml-1">Indexing Activity</div>
-                      </div>
-                    ),
-                    // Deep-link shortcut into the "Active (running + queued)"
-                    // status filter on the Existing Connectors table.
-                    link: "/admin/indexing/status?status=active",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <TriangleAlertIcon size={18} />
-                        <div className="ml-1">Failed Indexing</div>
-                      </div>
-                    ),
-                    // Deep-link shortcut into the "Failed" status filter on
-                    // the Existing Connectors table.
-                    link: "/admin/indexing/status?status=failed",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <ConnectorIcon size={18} />
-                        <div className="ml-1.5">Add Connector</div>
-                      </div>
-                    ),
-                    link: "/admin/add-connector",
-                  },
-                ],
-              },
-              {
-                name: "Document Management",
-                items: [
-                  {
-                    name: (
-                      <div className="flex">
-                        <BookmarkIcon size={18} />
-                        <div className="ml-1">Document Sets</div>
-                      </div>
-                    ),
-                    link: "/admin/documents/sets",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <ZoomInIcon size={18} />
-                        <div className="ml-1">Explorer</div>
-                      </div>
-                    ),
-                    link: "/admin/documents/explorer",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <ThumbsUpIcon size={18} />
-                        <div className="ml-1">Feedback</div>
-                      </div>
-                    ),
-                    link: "/admin/documents/feedback",
-                  },
-                ],
-              },
-              {
-                name: "Custom Assistants",
-                items: [
-                  {
-                    name: (
-                      <div className="flex">
-                        <RobotIcon size={18} />
-                        <div className="ml-1">Assistants</div>
-                      </div>
-                    ),
-                    link: "/admin/assistants",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <FiSlack size={18} />
-                        <div className="ml-1">Slack Bots</div>
-                      </div>
-                    ),
-                    link: "/admin/bot",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <FiTool size={18} className="my-auto" />
-                        <div className="ml-1">Tools</div>
-                      </div>
-                    ),
-                    link: "/admin/tools",
-                  },
-                ],
-              },
-              {
-                name: "Model Configs",
-                items: [
-                  {
-                    name: (
-                      <div className="flex">
-                        <FiCpu size={18} />
-                        <div className="ml-1">LLM</div>
-                      </div>
-                    ),
-                    link: "/admin/models/llm",
-                  },
-                  {
-                    name: (
-                      <div className="flex">
-                        <FiPackage size={18} />
-                        <div className="ml-1">Embedding</div>
-                      </div>
-                    ),
-                    link: "/admin/models/embedding",
-                  },
-                ],
-              },
-              {
-                name: "User Management",
-                items: [
-                  {
-                    name: (
-                      <div className="flex">
-                        <UsersIcon size={18} />
-                        <div className="ml-1">Users</div>
-                      </div>
-                    ),
-                    link: "/admin/users",
-                  },
-                  ...(SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED
-                    ? [
-                        {
-                          name: (
-                            <div className="flex">
-                              <GroupsIcon size={18} />
-                              <div className="ml-1">Groups</div>
-                            </div>
-                          ),
-                          link: "/admin/groups",
-                        },
-                        {
-                          name: (
-                            <div className="flex">
-                              <KeyIcon size={18} />
-                              <div className="ml-1">API Keys</div>
-                            </div>
-                          ),
-                          link: "/admin/api-key",
-                        },
-                      ]
-                    : []),
-                  {
-                    name: (
-                      <div className="flex">
-                        <FiShield size={18} />
-                        <div className="ml-1">Token Rate Limits</div>
-                      </div>
-                    ),
-                    link: "/admin/token-rate-limits",
-                  },
-                ],
-              },
-              {
-                name: "Analytics",
-                items: [
-                  {
-                    name: (
-                      <div className="flex">
-                        <FiBarChart2 size={18} />
-                        <div className="ml-1">Usage Analytics</div>
-                      </div>
-                    ),
-                    link: "/admin/analytics",
-                  },
-                ],
-              },
-              ...(SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED
-                ? [
+            <AdminSidebar
+              collections={[
+                {
+                  name: "Connectors",
+                  items: [
                     {
-                      name: "Performance",
-                      items: [
-                        {
-                          name: (
-                            <div className="flex">
-                              <FiActivity size={18} />
-                              <div className="ml-1">Usage Statistics</div>
-                            </div>
-                          ),
-                          link: "/admin/performance/usage",
-                        },
-                        {
-                          name: (
-                            <div className="flex">
-                              <DatabaseIcon size={18} />
-                              <div className="ml-1">Query History</div>
-                            </div>
-                          ),
-                          link: "/admin/performance/query-history",
-                        },
-                        {
-                          name: (
-                            <div className="flex">
-                              <FiBarChart2 size={18} />
-                              <div className="ml-1">Custom Analytics</div>
-                            </div>
-                          ),
-                          link: "/admin/performance/custom-analytics",
-                        },
-                      ],
+                      name: (
+                        <div className="flex">
+                          <NotebookIcon size={18} />
+                          <div className="ml-1">Existing Connectors</div>
+                        </div>
+                      ),
+                      link: "/admin/indexing/status",
                     },
-                  ]
-                : []),
-              {
-                name: "Settings",
-                items: [
-                  {
-                    name: (
-                      <div className="flex">
-                        <FiSettings size={18} />
-                        <div className="ml-1">Workspace Settings</div>
-                      </div>
-                    ),
-                    link: "/admin/settings",
-                  },
-                  ...(SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED
-                    ? [
-                        {
-                          name: (
-                            <div className="flex">
-                              <FiImage size={18} />
-                              <div className="ml-1">Whitelabeling</div>
-                            </div>
-                          ),
-                          link: "/admin/whitelabeling",
-                        },
-                      ]
-                    : []),
-                ],
-              },
-            ]}
-          />
+                    {
+                      name: (
+                        <div className="flex">
+                          <BarChartIcon size={18} />
+                          <div className="ml-1">Indexing Activity</div>
+                        </div>
+                      ),
+                      // Deep-link shortcut into the "Active (running + queued)"
+                      // status filter on the Existing Connectors table.
+                      link: "/admin/indexing/status?status=active",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <TriangleAlertIcon size={18} />
+                          <div className="ml-1">Failed Indexing</div>
+                        </div>
+                      ),
+                      // Deep-link shortcut into the "Failed" status filter on
+                      // the Existing Connectors table.
+                      link: "/admin/indexing/status?status=failed",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <ConnectorIcon size={18} />
+                          <div className="ml-1.5">Add Connector</div>
+                        </div>
+                      ),
+                      link: "/admin/add-connector",
+                    },
+                  ],
+                },
+                {
+                  name: "Document Management",
+                  items: [
+                    {
+                      name: (
+                        <div className="flex">
+                          <BookmarkIcon size={18} />
+                          <div className="ml-1">Document Sets</div>
+                        </div>
+                      ),
+                      link: "/admin/documents/sets",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <ZoomInIcon size={18} />
+                          <div className="ml-1">Explorer</div>
+                        </div>
+                      ),
+                      link: "/admin/documents/explorer",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <ThumbsUpIcon size={18} />
+                          <div className="ml-1">Feedback</div>
+                        </div>
+                      ),
+                      link: "/admin/documents/feedback",
+                    },
+                  ],
+                },
+                {
+                  name: "Custom Assistants",
+                  items: [
+                    {
+                      name: (
+                        <div className="flex">
+                          <RobotIcon size={18} />
+                          <div className="ml-1">Assistants</div>
+                        </div>
+                      ),
+                      link: "/admin/assistants",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiSlack size={18} />
+                          <div className="ml-1">Slack Bots</div>
+                        </div>
+                      ),
+                      link: "/admin/bot",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiUserPlus size={18} />
+                          <div className="ml-1">Onboarding requests</div>
+                        </div>
+                      ),
+                      link: "/admin/onboarding",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiTool size={18} className="my-auto" />
+                          <div className="ml-1">Tools</div>
+                        </div>
+                      ),
+                      link: "/admin/tools",
+                    },
+                  ],
+                },
+                {
+                  name: "Model Configs",
+                  items: [
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiCpu size={18} />
+                          <div className="ml-1">LLM</div>
+                        </div>
+                      ),
+                      link: "/admin/models/llm",
+                    },
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiPackage size={18} />
+                          <div className="ml-1">Embedding</div>
+                        </div>
+                      ),
+                      link: "/admin/models/embedding",
+                    },
+                  ],
+                },
+                {
+                  name: "User Management",
+                  items: [
+                    {
+                      name: (
+                        <div className="flex">
+                          <UsersIcon size={18} />
+                          <div className="ml-1">Users</div>
+                        </div>
+                      ),
+                      link: "/admin/users",
+                    },
+                    ...(SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED
+                      ? [
+                          {
+                            name: (
+                              <div className="flex">
+                                <GroupsIcon size={18} />
+                                <div className="ml-1">Groups</div>
+                              </div>
+                            ),
+                            link: "/admin/groups",
+                          },
+                          {
+                            name: (
+                              <div className="flex">
+                                <KeyIcon size={18} />
+                                <div className="ml-1">API Keys</div>
+                              </div>
+                            ),
+                            link: "/admin/api-key",
+                          },
+                        ]
+                      : []),
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiShield size={18} />
+                          <div className="ml-1">Token Rate Limits</div>
+                        </div>
+                      ),
+                      link: "/admin/token-rate-limits",
+                    },
+                  ],
+                },
+                {
+                  name: "Analytics",
+                  items: [
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiBarChart2 size={18} />
+                          <div className="ml-1">Usage Analytics</div>
+                        </div>
+                      ),
+                      link: "/admin/analytics",
+                    },
+                  ],
+                },
+                ...(SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED
+                  ? [
+                      {
+                        name: "Performance",
+                        items: [
+                          {
+                            name: (
+                              <div className="flex">
+                                <FiActivity size={18} />
+                                <div className="ml-1">Usage Statistics</div>
+                              </div>
+                            ),
+                            link: "/admin/performance/usage",
+                          },
+                          {
+                            name: (
+                              <div className="flex">
+                                <DatabaseIcon size={18} />
+                                <div className="ml-1">Query History</div>
+                              </div>
+                            ),
+                            link: "/admin/performance/query-history",
+                          },
+                          {
+                            name: (
+                              <div className="flex">
+                                <FiBarChart2 size={18} />
+                                <div className="ml-1">Custom Analytics</div>
+                              </div>
+                            ),
+                            link: "/admin/performance/custom-analytics",
+                          },
+                        ],
+                      },
+                    ]
+                  : []),
+                {
+                  name: "Settings",
+                  items: [
+                    {
+                      name: (
+                        <div className="flex">
+                          <FiSettings size={18} />
+                          <div className="ml-1">Workspace Settings</div>
+                        </div>
+                      ),
+                      link: "/admin/settings",
+                    },
+                    ...(SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED
+                      ? [
+                          {
+                            name: (
+                              <div className="flex">
+                                <FiImage size={18} />
+                                <div className="ml-1">Whitelabeling</div>
+                              </div>
+                            ),
+                            link: "/admin/whitelabeling",
+                          },
+                        ]
+                      : []),
+                  ],
+                },
+              ]}
+            />
           </Suspense>
         </div>
         <div className="px-12 pt-8 pb-8 h-full overflow-y-auto w-full">

--- a/web/src/lib/onboarding/clientChecks.test.ts
+++ b/web/src/lib/onboarding/clientChecks.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkChannel,
+  checkChannelLink,
+  checkJql,
+  checkUrl,
+  SOURCE_CLIENT_CHECK,
+} from "./clientChecks";
+
+describe("checkChannelLink (bot channel must be a link)", () => {
+  it("accepts a channel link", () => {
+    expect(
+      checkChannelLink("https://uipath-product.slack.com/archives/C0ABC123/p1")
+    ).toBeNull();
+  });
+  it("accepts a <#…> mention and a raw id", () => {
+    expect(checkChannelLink("<#C0ABC123|help-team>")).toBeNull();
+    expect(checkChannelLink("C0ABC123")).toBeNull();
+  });
+  it("rejects a bare channel name", () => {
+    expect(checkChannelLink("help-automation-suite")).toMatch(/link/i);
+    expect(checkChannelLink("#help-team")).toMatch(/link/i);
+  });
+  it("treats empty as no hint", () => {
+    expect(checkChannelLink("")).toBeNull();
+    expect(checkChannelLink("   ")).toBeNull();
+  });
+});
+
+describe("checkChannel (additional slack source, name-friendly)", () => {
+  it("accepts a lowercase name, id, link", () => {
+    expect(checkChannel("help-team")).toBeNull();
+    expect(checkChannel("#help-team")).toBeNull();
+    expect(checkChannel("C0ABC123")).toBeNull();
+  });
+  it("flags spaces and uppercase", () => {
+    expect(checkChannel("help team")).toMatch(/spaces/i);
+    expect(checkChannel("Help-Team")).toMatch(/lowercase/i);
+  });
+});
+
+describe("checkUrl", () => {
+  it("accepts http(s) urls", () => {
+    expect(checkUrl("https://docs.uipath.com/x")).toBeNull();
+    expect(checkUrl("http://example.com")).toBeNull();
+  });
+  it("rejects non-urls", () => {
+    expect(checkUrl("docs.uipath.com")).toMatch(/https/i);
+    expect(checkUrl("ftp://x")).toMatch(/https/i);
+  });
+});
+
+describe("checkJql", () => {
+  it("accepts a plausible filter", () => {
+    expect(checkJql("project = ABC")).toBeNull();
+  });
+  it("rejects an empty/too-short filter", () => {
+    expect(checkJql("")).toMatch(/JQL/i);
+    expect(checkJql("a")).toMatch(/JQL/i);
+  });
+});
+
+describe("SOURCE_CLIENT_CHECK maps each source type", () => {
+  it("routes web/confluence to url, slack to channel, jira to jql", () => {
+    expect(SOURCE_CLIENT_CHECK.web("nope")).toMatch(/https/i);
+    expect(
+      SOURCE_CLIENT_CHECK.confluence("https://x.atlassian.net")
+    ).toBeNull();
+    expect(SOURCE_CLIENT_CHECK.slack("Bad Name")).toMatch(/lowercase|spaces/i);
+    expect(SOURCE_CLIENT_CHECK.jira("project = ABC")).toBeNull();
+  });
+});

--- a/web/src/lib/onboarding/clientChecks.ts
+++ b/web/src/lib/onboarding/clientChecks.ts
@@ -1,0 +1,51 @@
+// Lightweight, synchronous client-side format checks for the onboarding form.
+// They catch obvious mistakes instantly (before any network round-trip) and
+// gate the debounced backend validation. Each returns a short hint string, or
+// null when the value looks fine to send to the server.
+
+import { OnboardingSourceType } from "./interfaces";
+
+export type ClientCheck = (value: string) => string | null;
+
+export const checkChannel: ClientCheck = (v) => {
+  const raw = v.trim().replace(/^#/, "");
+  if (!raw) return null;
+  // A channel id or a pasted link/mention — let the server resolve it.
+  if (
+    /^C[A-Z0-9]{6,}$/.test(raw) ||
+    raw.includes("slack.com/") ||
+    raw.includes("<#")
+  )
+    return null;
+  if (/\s/.test(raw))
+    return "Channel names have no spaces — paste a link to be sure.";
+  if (/[A-Z]/.test(raw)) return "Channel names are lowercase.";
+  return null;
+};
+
+// The bot channel must be a link (a name can't be verified reliably). Accept a
+// channel link / <#…> mention / raw id; anything else prompts for the link.
+export const checkChannelLink: ClientCheck = (v) => {
+  const raw = v.trim();
+  if (!raw) return null;
+  if (
+    /\/archives\/C[A-Z0-9]+/.test(raw) ||
+    /^<#C[A-Z0-9]+/.test(raw) ||
+    /^C[A-Z0-9]{6,}$/.test(raw)
+  )
+    return null;
+  return "Paste the channel link, not the name (steps below).";
+};
+
+export const checkUrl: ClientCheck = (v) =>
+  /^https?:\/\//i.test(v.trim()) ? null : "Start with https://";
+
+export const checkJql: ClientCheck = (v) =>
+  v.trim().length < 3 ? "Enter a JQL filter, e.g. project = ABC" : null;
+
+export const SOURCE_CLIENT_CHECK: Record<OnboardingSourceType, ClientCheck> = {
+  web: checkUrl,
+  confluence: checkUrl,
+  slack: checkChannel,
+  jira: checkJql,
+};

--- a/web/src/lib/onboarding/interfaces.ts
+++ b/web/src/lib/onboarding/interfaces.ts
@@ -39,7 +39,13 @@ export interface ValidationResult {
 }
 
 export type OnboardingRequestStatus =
-  "pending" | "rejected" | "provisioning" | "indexing" | "complete" | "failed";
+  | "pending"
+  | "rejected"
+  | "cancelled"
+  | "provisioning"
+  | "indexing"
+  | "complete"
+  | "failed";
 
 export interface OnboardingRequestSnapshot {
   id: number;

--- a/web/src/lib/onboarding/interfaces.ts
+++ b/web/src/lib/onboarding/interfaces.ts
@@ -1,0 +1,93 @@
+// Types for the self-serve Darwin onboarding flow. Mirrors the backend models in
+// danswer/server/features/onboarding/.
+
+export type OnboardingSourceType = "web" | "confluence" | "github" | "slack";
+
+export interface OnboardingSource {
+  type: OnboardingSourceType;
+  value: string;
+  label?: string | null;
+}
+
+export interface ChannelRef {
+  channel_id: string;
+  channel_name: string;
+}
+
+export interface OnboardingSubmitRequest {
+  team_name: string;
+  channel: ChannelRef;
+  response_type: "citations" | "quotes";
+  respond_tag_only: boolean;
+  system_prompt: string;
+  task_prompt: string;
+  sme: { enabled: boolean; group_name: string };
+  oncall: { enabled: boolean; schedule: string };
+  jira: {
+    enabled: boolean;
+    project_key: string;
+    issue_type: string;
+    component: string;
+  };
+  sources: OnboardingSource[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  message: string;
+  resolved: Record<string, unknown>;
+}
+
+export type OnboardingRequestStatus =
+  "pending" | "rejected" | "provisioning" | "indexing" | "complete" | "failed";
+
+export interface OnboardingRequestSnapshot {
+  id: number;
+  requester_email: string;
+  status: OnboardingRequestStatus;
+  payload: OnboardingSubmitRequest;
+  decision_reason: string | null;
+  error_msg: string | null;
+  persona_id: number | null;
+  document_set_id: number | null;
+  slack_bot_config_id: number | null;
+  cc_pair_ids: number[] | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SourceStatus {
+  cc_pair_id: number;
+  name: string;
+  status: string;
+  docs_indexed: number;
+  error_msg: string | null;
+}
+
+export interface OnboardingStatusResponse {
+  request_id: number;
+  status: OnboardingRequestStatus;
+  sources: SourceStatus[];
+}
+
+export type ValidateKind =
+  "slack_channel" | "slack_group" | "confluence" | "docs";
+
+export async function validateOnboardingField(
+  kind: ValidateKind,
+  value: string
+): Promise<ValidationResult> {
+  const res = await fetch("/api/onboarding/validate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ kind, value }),
+  });
+  if (!res.ok) {
+    return {
+      valid: false,
+      message: `Couldn't validate (${res.status})`,
+      resolved: {},
+    };
+  }
+  return (await res.json()) as ValidationResult;
+}

--- a/web/src/lib/onboarding/interfaces.ts
+++ b/web/src/lib/onboarding/interfaces.ts
@@ -1,7 +1,7 @@
 // Types for the self-serve Darwin onboarding flow. Mirrors the backend models in
 // danswer/server/features/onboarding/.
 
-export type OnboardingSourceType = "web" | "confluence" | "github" | "slack";
+export type OnboardingSourceType = "web" | "confluence" | "slack" | "jira";
 
 export interface OnboardingSource {
   type: OnboardingSourceType;
@@ -71,7 +71,7 @@ export interface OnboardingStatusResponse {
 }
 
 export type ValidateKind =
-  "slack_channel" | "slack_group" | "confluence" | "github" | "docs";
+  "slack_channel" | "slack_group" | "confluence" | "github" | "jira" | "docs";
 
 export async function validateOnboardingField(
   kind: ValidateKind,

--- a/web/src/lib/onboarding/interfaces.ts
+++ b/web/src/lib/onboarding/interfaces.ts
@@ -76,6 +76,36 @@ export interface OnboardingStatusResponse {
   sources: SourceStatus[];
 }
 
+export interface SourceStatusCounts {
+  total: number;
+  succeeded: number;
+  indexing: number;
+  pending: number;
+  failed: number;
+}
+
+// Roll the per-source scrape statuses up into counts for an at-a-glance summary
+// (e.g. "4/6 succeeded · 1 indexing · 1 failed"). Anything that isn't
+// success/in_progress/failed (i.e. not_started) counts as pending.
+export function countSourceStatuses(
+  sources: SourceStatus[]
+): SourceStatusCounts {
+  const counts: SourceStatusCounts = {
+    total: sources.length,
+    succeeded: 0,
+    indexing: 0,
+    pending: 0,
+    failed: 0,
+  };
+  for (const s of sources) {
+    if (s.status === "success") counts.succeeded += 1;
+    else if (s.status === "in_progress") counts.indexing += 1;
+    else if (s.status === "failed") counts.failed += 1;
+    else counts.pending += 1;
+  }
+  return counts;
+}
+
 export type ValidateKind =
   "slack_channel" | "slack_group" | "confluence" | "github" | "jira" | "docs";
 

--- a/web/src/lib/onboarding/interfaces.ts
+++ b/web/src/lib/onboarding/interfaces.ts
@@ -22,7 +22,7 @@ export interface OnboardingSubmitRequest {
   system_prompt: string;
   task_prompt: string;
   sme: { enabled: boolean; group_name: string };
-  oncall: { enabled: boolean; schedule: string };
+  oncall: { enabled: boolean; schedule: string; handles: string };
   jira: {
     enabled: boolean;
     project_key: string;

--- a/web/src/lib/onboarding/interfaces.ts
+++ b/web/src/lib/onboarding/interfaces.ts
@@ -71,7 +71,7 @@ export interface OnboardingStatusResponse {
 }
 
 export type ValidateKind =
-  "slack_channel" | "slack_group" | "confluence" | "docs";
+  "slack_channel" | "slack_group" | "confluence" | "github" | "docs";
 
 export async function validateOnboardingField(
   kind: ValidateKind,

--- a/web/src/lib/safeRedirect.test.ts
+++ b/web/src/lib/safeRedirect.test.ts
@@ -21,6 +21,9 @@ describe("getSafeNextPath", () => {
     it("drops any fragment", () => {
       expect(getSafeNextPath("/chat?x=1#frag")).toBe("/chat?x=1");
     });
+    it("/onboarding (allowlisted entry point)", () => {
+      expect(getSafeNextPath("/onboarding")).toBe("/onboarding");
+    });
   });
 
   describe("rejects open-redirect / off-origin attempts", () => {

--- a/web/src/lib/safeRedirect.ts
+++ b/web/src/lib/safeRedirect.ts
@@ -18,7 +18,7 @@ export const LOGIN_NEXT_COOKIE = "darwin_login_next";
 
 // App pages a post-login redirect may land on. Deliberately excludes /admin,
 // /auth, etc. — a login flow should never bounce a user into a privileged route.
-const ALLOWED_NEXT_PREFIXES = ["/chat"];
+const ALLOWED_NEXT_PREFIXES = ["/chat", "/onboarding"];
 
 const MAX_NEXT_LENGTH = 512;
 


### PR DESCRIPTION
## Self-serve team onboarding for Darwin

Adds an end-to-end self-serve onboarding flow: a validated request form → admin
approval → automatic provisioning (connectors, document set, assistant, Slack
bot config) → background finalizer, with Slack notifications throughout.

### Highlights
- **Form + validation**: inline-validated request form (Slack channel, docs,
  Confluence, Jira, GitHub sources); requester self-edit/cancel of pending
  requests; admin edit-and-approve in the same shared form; SSO-gated.
- **Two-phase provisioning**: approve → connectors/cc_pairs + high-priority
  indexing → INDEXING; background finalizer creates the document set, assistant
  (prompt + persona **with the SearchTool**), and Slack bot config → COMPLETE.
  Idempotent + checkpointed so a pod crash resumes without duplicating artifacts;
  "in-progress wins over failed" so a request never shows FAILED while a source
  is still scraping.
- **Admin queue**: status-filter pills + pagination, per-source scrape status
  with connector links, a milestone "journey" stepper, aggregate rollups, and a
  read-only view for finished requests.
- **Slack notifications**: internal ops → #darwin-devs (admin link + real
  errors); customer-facing thread → #help-darwin (requester @mentioned on submit,
  lifecycle updates as threaded replies; channel configurable via
  `ONBOARDING_CLIENT_CHANNEL`).
- Also folds in the live **slack citation-link fixes** (`feature/slack_link_fix`)
  so this branch doesn't regress them.

### Ops
- New table `onboarding_request` (+ `help_thread_ts`) — additive migrations.
- New env: `ONBOARDING_NOTIFY_CHANNEL`, `ONBOARDING_CLIENT_CHANNEL`.
- Deployed to prod as backend **vha-220** / web **vha-117**.

### Tests
Onboarding unit tests cover the finalizer state machine (idempotency, resume,
crash-recovery, notify-failure, SearchTool attachment), notifications, provision
builders + off-by-one regression, and frontend client checks.
